### PR TITLE
test(core): cover trimmed string serde helpers

### DIFF
--- a/teaql-core/src/serde_utils.rs
+++ b/teaql-core/src/serde_utils.rs
@@ -40,3 +40,79 @@ pub mod trimmed_opt_string {
         Ok(opt.map(|s| s.trim().to_owned()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+
+    use super::{trimmed_opt_string, trimmed_string};
+
+    #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+    struct TrimmedFields {
+        #[serde(with = "trimmed_string")]
+        required: String,
+        #[serde(default, with = "trimmed_opt_string")]
+        optional: Option<String>,
+    }
+
+    #[test]
+    fn trimmed_string_helpers_trim_during_serialization() {
+        let fields = TrimmedFields {
+            required: "  required value\n".to_owned(),
+            optional: Some("\toptional value  ".to_owned()),
+        };
+
+        assert_eq!(
+            serde_json::to_value(fields).expect("trimmed fields should serialize"),
+            serde_json::json!({
+                "required": "required value",
+                "optional": "optional value"
+            })
+        );
+    }
+
+    #[test]
+    fn trimmed_optional_string_preserves_none_during_serialization() {
+        let fields = TrimmedFields {
+            required: " value ".to_owned(),
+            optional: None,
+        };
+
+        assert_eq!(
+            serde_json::to_value(fields).expect("trimmed fields should serialize"),
+            serde_json::json!({
+                "required": "value",
+                "optional": null
+            })
+        );
+    }
+
+    #[test]
+    fn trimmed_string_helpers_trim_during_deserialization() {
+        let fields: TrimmedFields = serde_json::from_value(serde_json::json!({
+            "required": "  required value\n",
+            "optional": "\toptional value  "
+        }))
+        .expect("trimmed fields should deserialize");
+
+        assert_eq!(
+            fields,
+            TrimmedFields {
+                required: "required value".to_owned(),
+                optional: Some("optional value".to_owned()),
+            }
+        );
+    }
+
+    #[test]
+    fn trimmed_optional_string_keeps_whitespace_only_input_as_some_empty() {
+        let fields: TrimmedFields = serde_json::from_value(serde_json::json!({
+            "required": " value ",
+            "optional": " \t\n "
+        }))
+        .expect("trimmed fields should deserialize");
+
+        assert_eq!(fields.required, "value");
+        assert_eq!(fields.optional, Some(String::new()));
+    }
+}


### PR DESCRIPTION
Closes #21

## Summary
- cover required and optional string trimming during serialization
- cover trimming during deserialization
- verify None stays None and whitespace-only Some becomes Some empty string

## Verification
- cargo fmt --all -- --check
- cargo test -p teaql-core serde_utils
- cargo clippy -p teaql-core --all-targets --all-features
- cargo test --workspace --exclude teaql-provider-linux --no-fail-fast

The unfiltered workspace cannot build on macOS because procfs is Linux/Android-only; GitHub CI runs on Ubuntu.