### PR TITLE
feat: add teaql-cloud-core crate with cloud integration trait definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,7 +1554,7 @@ dependencies = [
  "quote",
  "syn 2.0.118",
  "termcolor",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1581,7 +1581,7 @@ dependencies = [
  "serde",
  "serde_json",
  "socket2 0.5.10",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -1625,7 +1625,7 @@ dependencies = [
  "sha2 0.10.9",
  "smallvec",
  "subprocess",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "uuid",
  "zstd",
@@ -2511,6 +2511,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2628,6 +2638,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2683,6 +2704,17 @@ dependencies = [
  "serde_json",
  "teaql-core",
  "teaql-runtime",
+ "tokio",
+]
+
+[[package]]
+name = "teaql-cloud-core"
+version = "4.1.1"
+dependencies = [
+ "async-trait",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
  "tokio",
 ]
 
@@ -2857,7 +2889,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -2869,6 +2910,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -2935,6 +2987,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "teaql-macros",
     "examples", "teaql-data-service", "teaql-web-integration-axum", "teaql-cache-integration-redis", "teaql-provider-meilisearch",
     "teaql-provider-linux",
+    "teaql-cloud-core",
 ]
 resolver = "2"
 

--- a/docs/2026-07-20-cloud-integration-design.md
+++ b/docs/2026-07-20-cloud-integration-design.md
@@ -1,0 +1,1172 @@
+# TeaQL Cloud Integration Design
+
+> **Date**: 2026-07-20
+> **Branch**: `feature/cloud-integration`
+> **Status**: Design Phase
+
+## 1. Background
+
+将基于 teaql-rs 构建的 Rust 服务嵌入以 Java 为主的微服务架构中。Java 侧使用 **Nacos** 作为服务注册发现与配置中心。
+
+### 1.1 Design Decisions
+
+| 项目 | 决策 |
+|------|------|
+| 架构风格 | **核心 trait crate + 独立后端 crate** |
+| `teaql-cloud-core` 是否依赖 `teaql-runtime` | **否**，两个体系完全独立，仅在用户应用层组合 |
+| 服务发现优先后端 | **Nacos** |
+| Nacos 协议版本 | **v2 gRPC**（基于 `nacos-sdk` crate v0.8，原生 gRPC 长连接） |
+| Actuator 端点范围 | health（含 liveness/readiness）+ info + metrics |
+| Metrics 格式 | **Prometheus exposition format** |
+| Loggers | 暂不实现，后续再设计 |
+| Graceful Shutdown | **实现**，集成 tokio signal |
+
+---
+
+## 2. Crate Overview
+
+```
+teaql-cloud-core          trait 定义 + 公共模型 (零后端依赖)
+teaql-cloud-actuator      Axum 运维端点 (health / info / metrics)
+teaql-cloud-nacos         Nacos v2 gRPC 实现 (基于 nacos-sdk crate, pinned =0.8)
+teaql-cloud-starter       一行启动, 打包所有 cloud 能力 (类似 Spring Boot Starter)
+```
+
+### 2.1 Dependency Graph
+
+```
+teaql-cloud-core                          (serde, async-trait, tokio, thiserror)
+    ↑                  ↑
+teaql-cloud-actuator   teaql-cloud-nacos
+    (axum)                (nacos-sdk)
+                   ↑
+              用户应用
+         (+ teaql-runtime, teaql-web-integration-axum)
+```
+
+> **重要**: `teaql-cloud-core` 不依赖 `teaql-runtime`。
+> 这意味着 cloud 模块可以脱离 teaql 独立使用（纯 Axum 项目也能用）。
+
+### 2.2 Future Backend Crates
+
+同一套 trait，未来可扩展：
+
+| crate | 后端 | 协议 |
+|-------|------|------|
+| `teaql-cloud-consul` | Consul | HTTP Blocking Query |
+| `teaql-cloud-etcd` | etcd | gRPC Watch / Lease |
+| `teaql-cloud-k8s` | Kubernetes | Watch API (kube-rs) |
+
+不同后端的差异通过 trait 统一：
+
+| 维度 | Nacos v2 | etcd | Consul | Kubernetes |
+|------|----------|------|--------|------------|
+| 服务注册 | gRPC | KV + Lease | Catalog + Agent | Service/Endpoint |
+| 配置变更 | gRPC Push | Watch stream | Blocking Query | Watch API |
+| 心跳 | gRPC 长连接 (连接即心跳) | Lease KeepAlive | TTL Check | 无需 (kubelet) |
+| 命名空间 | namespace + group | key prefix | datacenter | namespace |
+
+---
+
+## 3. `teaql-cloud-core` — Trait Definitions
+
+### 3.1 Directory Structure
+
+```
+teaql-cloud-core/
+├── Cargo.toml
+└── src/
+    ├── lib.rs              # 公共 re-export
+    ├── error.rs            # CloudError 统一错误
+    ├── model.rs            # ServiceInstance, ServiceGroup, ConfigId
+    ├── registry.rs         # ServiceRegistry trait
+    ├── discovery.rs        # ServiceDiscovery trait
+    ├── config.rs           # ConfigSource trait
+    ├── health.rs           # HealthIndicator trait + HealthStatus
+    ├── metrics.rs          # MetricsCollector trait + Prometheus 格式化
+    └── lifecycle.rs        # ServiceLifecycle, GracefulShutdown
+```
+
+### 3.2 `Cargo.toml`
+
+```toml
+[package]
+name = "teaql-cloud-core"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = "1"
+thiserror = { workspace = true }
+async-trait = { workspace = true }
+tokio = { version = "1", features = ["sync", "signal"] }
+```
+
+### 3.3 `error.rs`
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum CloudError {
+    #[error("Discovery error: {0}")]
+    Discovery(String),
+
+    #[error("Registration error: {0}")]
+    Registration(String),
+
+    #[error("Config error: {0}")]
+    Config(String),
+
+    #[error("Health check error: {0}")]
+    Health(String),
+
+    #[error("Network error: {source}")]
+    Network {
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[error("Serialization error: {0}")]
+    Serialization(String),
+
+    #[error("Timeout after {duration:?}")]
+    Timeout { duration: std::time::Duration },
+
+    #[error("Shutdown in progress")]
+    ShuttingDown,
+}
+```
+
+### 3.4 `model.rs`
+
+```rust
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// 服务实例 — 所有后端的公共模型
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServiceInstance {
+    pub service_name: String,
+    pub instance_id: String,
+    pub ip: String,
+    pub port: u16,
+    pub weight: f64,
+    pub healthy: bool,
+    pub metadata: HashMap<String, String>,
+}
+
+impl ServiceInstance {
+    pub fn new(
+        service_name: impl Into<String>,
+        ip: impl Into<String>,
+        port: u16,
+    ) -> Self {
+        let service_name = service_name.into();
+        let ip = ip.into();
+        let instance_id = format!("{}-{}-{}", service_name, ip, port);
+        Self {
+            service_name,
+            instance_id,
+            ip,
+            port,
+            weight: 1.0,
+            healthy: true,
+            metadata: HashMap::new(),
+        }
+    }
+
+    pub fn with_metadata(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Self {
+        self.metadata.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn with_weight(mut self, weight: f64) -> Self {
+        self.weight = weight;
+        self
+    }
+
+    pub fn address(&self) -> String {
+        format!("{}:{}", self.ip, self.port)
+    }
+}
+
+impl Default for ServiceInstance {
+    fn default() -> Self {
+        Self {
+            service_name: String::new(),
+            instance_id: String::new(),
+            ip: "127.0.0.1".to_string(),
+            port: 8080,
+            weight: 1.0,
+            healthy: true,
+            metadata: HashMap::new(),
+        }
+    }
+}
+
+/// 服务分组 — 不同后端映射不同概念
+///
+/// - Nacos: namespace + group
+/// - Consul: datacenter
+/// - etcd: key prefix
+/// - K8s: namespace
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ServiceGroup {
+    pub namespace: Option<String>,
+    pub group: Option<String>,
+}
+
+impl ServiceGroup {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_namespace(mut self, ns: impl Into<String>) -> Self {
+        self.namespace = Some(ns.into());
+        self
+    }
+
+    pub fn with_group(mut self, group: impl Into<String>) -> Self {
+        self.group = Some(group.into());
+        self
+    }
+}
+
+/// 配置标识
+#[derive(Debug, Clone)]
+pub struct ConfigId {
+    pub data_id: String,
+    pub group: String,
+    pub namespace: Option<String>,
+}
+
+impl ConfigId {
+    pub fn new(
+        data_id: impl Into<String>,
+        group: impl Into<String>,
+    ) -> Self {
+        Self {
+            data_id: data_id.into(),
+            group: group.into(),
+            namespace: None,
+        }
+    }
+
+    pub fn with_namespace(mut self, ns: impl Into<String>) -> Self {
+        self.namespace = Some(ns.into());
+        self
+    }
+}
+```
+
+### 3.5 `registry.rs`
+
+```rust
+use crate::{CloudError, ServiceInstance};
+use std::future::Future;
+use std::time::Duration;
+
+/// 服务注册能力
+///
+/// 生命周期: register → heartbeat (循环) → deregister
+///
+/// 不同后端心跳机制:
+/// - Nacos v2: gRPC 长连接本身就是心跳, heartbeat() 可以是 no-op
+/// - etcd: Lease KeepAlive
+/// - Consul: TTL Check + PUT
+/// - K8s: 无需心跳 (kubelet 管理)
+pub trait ServiceRegistry: Send + Sync {
+    fn register(
+        &self,
+        instance: &ServiceInstance,
+    ) -> impl Future<Output = Result<(), CloudError>> + Send;
+
+    fn deregister(
+        &self,
+        instance: &ServiceInstance,
+    ) -> impl Future<Output = Result<(), CloudError>> + Send;
+
+    fn heartbeat(
+        &self,
+        instance: &ServiceInstance,
+    ) -> impl Future<Output = Result<(), CloudError>> + Send;
+
+    /// 推荐的心跳间隔
+    /// Nacos v2 gRPC 长连接场景下可返回较大值或 None
+    fn heartbeat_interval(&self) -> Option<Duration> {
+        Some(Duration::from_secs(5))
+    }
+}
+```
+
+### 3.6 `discovery.rs`
+
+```rust
+use crate::{CloudError, ServiceGroup, ServiceInstance};
+use std::future::Future;
+
+/// 服务变更事件
+#[derive(Debug, Clone)]
+pub struct ServiceChangeEvent {
+    pub service_name: String,
+    pub instances: Vec<ServiceInstance>,
+}
+
+/// 服务发现能力
+pub trait ServiceDiscovery: Send + Sync {
+    /// 获取健康的服务实例列表
+    fn get_instances(
+        &self,
+        service_name: &str,
+        group: &ServiceGroup,
+    ) -> impl Future<Output = Result<Vec<ServiceInstance>, CloudError>> + Send;
+
+    /// 获取所有实例 (包括不健康的)
+    fn get_all_instances(
+        &self,
+        service_name: &str,
+        group: &ServiceGroup,
+    ) -> impl Future<Output = Result<Vec<ServiceInstance>, CloudError>> + Send {
+        self.get_instances(service_name, group)
+    }
+
+    /// 订阅服务变更
+    ///
+    /// Nacos v2: gRPC 服务端主动推送, 延迟极低
+    /// etcd: gRPC Watch stream
+    /// Consul: Blocking Query (long polling)
+    fn subscribe(
+        &self,
+        service_name: &str,
+        group: &ServiceGroup,
+        callback: Box<dyn Fn(ServiceChangeEvent) + Send + Sync>,
+    ) -> impl Future<Output = Result<SubscriptionHandle, CloudError>> + Send;
+}
+
+/// 取消订阅 handle
+pub struct SubscriptionHandle {
+    cancel: Box<dyn FnOnce() + Send>,
+}
+
+impl SubscriptionHandle {
+    pub fn new(cancel: impl FnOnce() + Send + 'static) -> Self {
+        Self { cancel: Box::new(cancel) }
+    }
+
+    pub fn unsubscribe(self) {
+        (self.cancel)();
+    }
+}
+```
+
+### 3.7 `config.rs`
+
+```rust
+use crate::CloudError;
+use std::future::Future;
+
+use crate::model::ConfigId;
+
+/// 配置源抽象
+pub trait ConfigSource: Send + Sync {
+    /// 获取配置 (返回原始字符串, 由调用方解析为 YAML/TOML/JSON)
+    fn get_config(
+        &self,
+        config_id: &ConfigId,
+    ) -> impl Future<Output = Result<String, CloudError>> + Send;
+
+    /// 发布配置
+    fn publish_config(
+        &self,
+        config_id: &ConfigId,
+        content: &str,
+    ) -> impl Future<Output = Result<(), CloudError>> + Send;
+
+    /// 监听配置变更
+    ///
+    /// Nacos v2: gRPC Push (服务端主动推送)
+    /// etcd: gRPC Watch stream
+    /// Consul: Blocking Query
+    fn watch(
+        &self,
+        config_id: &ConfigId,
+        callback: Box<dyn Fn(String) + Send + Sync>,
+    ) -> impl Future<Output = Result<WatchHandle, CloudError>> + Send;
+}
+
+/// 取消监听 handle
+pub struct WatchHandle {
+    cancel: Box<dyn FnOnce() + Send>,
+}
+
+impl WatchHandle {
+    pub fn new(cancel: impl FnOnce() + Send + 'static) -> Self {
+        Self { cancel: Box::new(cancel) }
+    }
+
+    pub fn unwatch(self) {
+        (self.cancel)();
+    }
+}
+```
+
+### 3.8 `health.rs`
+
+```rust
+use serde::Serialize;
+use std::collections::HashMap;
+use std::future::Future;
+
+/// 健康状态 — 兼容 Spring Boot Actuator 输出
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum HealthStatus {
+    Up,
+    Down,
+    Unknown,
+    /// 启动中: liveness = true, readiness = false
+    OutOfService,
+}
+
+impl HealthStatus {
+    /// 聚合: 任一 Down → Down, 任一 OutOfService → OutOfService
+    pub fn aggregate(statuses: &[HealthStatus]) -> HealthStatus {
+        if statuses.iter().any(|s| *s == HealthStatus::Down) {
+            HealthStatus::Down
+        } else if statuses.iter().any(|s| *s == HealthStatus::OutOfService) {
+            HealthStatus::OutOfService
+        } else if statuses.iter().all(|s| *s == HealthStatus::Up) {
+            HealthStatus::Up
+        } else {
+            HealthStatus::Unknown
+        }
+    }
+}
+
+/// 单个组件健康详情
+#[derive(Debug, Clone, Serialize)]
+pub struct HealthDetail {
+    pub status: HealthStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<serde_json::Value>,
+}
+
+impl HealthDetail {
+    pub fn up() -> Self {
+        Self { status: HealthStatus::Up, details: None }
+    }
+
+    pub fn down(reason: impl Into<String>) -> Self {
+        Self {
+            status: HealthStatus::Down,
+            details: Some(serde_json::json!({ "error": reason.into() })),
+        }
+    }
+
+    pub fn up_with_details(details: serde_json::Value) -> Self {
+        Self { status: HealthStatus::Up, details: Some(details) }
+    }
+}
+
+/// 健康指示器 — 每个要检查的组件实现一个
+pub trait HealthIndicator: Send + Sync {
+    /// 组件名 (如 "db", "nacos", "diskSpace")
+    fn name(&self) -> &str;
+
+    /// 执行健康检查
+    fn check(&self) -> impl Future<Output = HealthDetail> + Send;
+
+    /// 是否参与 readiness 判定 (默认 true)
+    fn contributes_to_readiness(&self) -> bool {
+        true
+    }
+}
+
+/// 聚合健康响应
+#[derive(Debug, Clone, Serialize)]
+pub struct HealthResponse {
+    pub status: HealthStatus,
+    pub components: HashMap<String, HealthDetail>,
+}
+```
+
+### 3.9 `metrics.rs`
+
+```rust
+use std::future::Future;
+
+/// 指标类型
+#[derive(Debug, Clone)]
+pub enum MetricValue {
+    Counter(f64),
+    Gauge(f64),
+    Histogram {
+        sum: f64,
+        count: u64,
+        buckets: Vec<(f64, u64)>,
+    },
+}
+
+/// 单个指标
+#[derive(Debug, Clone)]
+pub struct Metric {
+    pub name: String,
+    pub help: String,
+    pub labels: Vec<(String, String)>,
+    pub value: MetricValue,
+}
+
+/// 指标收集器
+pub trait MetricsCollector: Send + Sync {
+    fn collect(&self) -> impl Future<Output = Vec<Metric>> + Send;
+}
+
+/// 格式化为 Prometheus exposition format
+pub fn to_prometheus_exposition(metrics: &[Metric]) -> String {
+    let mut output = String::new();
+    for metric in metrics {
+        output.push_str(&format!("# HELP {} {}\n", metric.name, metric.help));
+        let type_str = match &metric.value {
+            MetricValue::Counter(_) => "counter",
+            MetricValue::Gauge(_) => "gauge",
+            MetricValue::Histogram { .. } => "histogram",
+        };
+        output.push_str(&format!("# TYPE {} {}\n", metric.name, type_str));
+
+        let labels_str = if metric.labels.is_empty() {
+            String::new()
+        } else {
+            let pairs: Vec<String> = metric.labels.iter()
+                .map(|(k, v)| format!("{}=\"{}\"", k, v))
+                .collect();
+            format!("{{{}}}", pairs.join(","))
+        };
+
+        match &metric.value {
+            MetricValue::Counter(v) | MetricValue::Gauge(v) => {
+                output.push_str(&format!("{}{} {}\n", metric.name, labels_str, v));
+            }
+            MetricValue::Histogram { sum, count, buckets } => {
+                for (le, c) in buckets {
+                    output.push_str(&format!(
+                        "{}_bucket{}{{le=\"{}\"}} {}\n",
+                        metric.name, labels_str, le, c
+                    ));
+                }
+                output.push_str(&format!("{}_sum{} {}\n", metric.name, labels_str, sum));
+                output.push_str(&format!("{}_count{} {}\n", metric.name, labels_str, count));
+            }
+        }
+    }
+    output
+}
+```
+
+### 3.10 `lifecycle.rs` — Graceful Shutdown
+
+```rust
+use crate::{CloudError, ServiceInstance, ServiceRegistry};
+use std::sync::Arc;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+
+/// 服务生命周期 Guard
+///
+/// 管理: register → heartbeat loop → (shutdown signal) → deregister → 等待在途请求
+///
+/// 用法:
+/// ```ignore
+/// let guard = ServiceLifecycle::start(registry, instance).await?;
+/// // ... 服务运行中 ...
+/// // Ctrl+C 或 guard.shutdown() 触发:
+/// //   1. 标记 readiness = false (不再接收新流量)
+/// //   2. deregister (从注册中心摘除)
+/// //   3. 等待 drain_duration (让在途请求完成)
+/// //   4. 退出
+/// ```
+pub struct ServiceLifecycle {
+    shutdown_tx: watch::Sender<bool>,
+    heartbeat_handle: JoinHandle<()>,
+    instance: ServiceInstance,
+    registry: Arc<dyn ServiceRegistry>,
+}
+
+impl ServiceLifecycle {
+    /// 启动服务生命周期: 注册 + 开始心跳
+    pub async fn start(
+        registry: Arc<dyn ServiceRegistry>,
+        instance: ServiceInstance,
+    ) -> Result<Self, CloudError> {
+        // 1. Register
+        registry.register(&instance).await?;
+
+        // 2. Start heartbeat loop (if backend needs it)
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let heartbeat_handle = {
+            let registry = registry.clone();
+            let instance = instance.clone();
+            let mut shutdown_rx = shutdown_rx.clone();
+
+            tokio::spawn(async move {
+                let interval = registry.heartbeat_interval();
+                if let Some(interval) = interval {
+                    loop {
+                        tokio::select! {
+                            _ = tokio::time::sleep(interval) => {
+                                let _ = registry.heartbeat(&instance).await;
+                            }
+                            _ = shutdown_rx.changed() => {
+                                break;
+                            }
+                        }
+                    }
+                }
+            })
+        };
+
+        Ok(Self {
+            shutdown_tx,
+            heartbeat_handle,
+            instance,
+            registry,
+        })
+    }
+
+    /// 返回一个 shutdown receiver, 用于 Axum graceful shutdown
+    pub fn shutdown_receiver(&self) -> watch::Receiver<bool> {
+        self.shutdown_tx.subscribe()
+    }
+
+    /// 主动触发 shutdown
+    pub async fn shutdown(self) -> Result<(), CloudError> {
+        // 1. Signal heartbeat to stop
+        let _ = self.shutdown_tx.send(true);
+
+        // 2. Wait for heartbeat task to finish
+        let _ = self.heartbeat_handle.await;
+
+        // 3. Deregister from service registry
+        self.registry.deregister(&self.instance).await?;
+
+        Ok(())
+    }
+}
+
+/// 安装系统信号处理, 在 SIGINT/SIGTERM 时自动 shutdown
+///
+/// 返回一个 Future, 在信号到达时完成
+pub async fn wait_for_shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+}
+```
+
+---
+
+## 4. `teaql-cloud-actuator` — Axum Endpoints
+
+### 4.1 Directory Structure
+
+```
+teaql-cloud-actuator/
+├── Cargo.toml
+└── src/
+    ├── lib.rs              # actuator_routes() 入口
+    ├── state.rs            # ActuatorState
+    ├── health_handler.rs   # /actuator/health, /liveness, /readiness
+    ├── info_handler.rs     # /actuator/info
+    └── metrics_handler.rs  # /actuator/metrics (Prometheus)
+```
+
+### 4.2 `Cargo.toml`
+
+```toml
+[package]
+name = "teaql-cloud-actuator"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+teaql-cloud-core = { workspace = true }
+axum = { version = "0.7", features = ["macros"] }
+serde = { workspace = true }
+serde_json = "1"
+tokio = { workspace = true }
+```
+
+### 4.3 Core Design
+
+```rust
+use axum::{Router, routing::get};
+use std::sync::Arc;
+use teaql_cloud_core::{HealthIndicator, MetricsCollector};
+
+/// 共享状态
+#[derive(Clone)]
+pub struct ActuatorState {
+    pub indicators: Vec<Arc<dyn HealthIndicator>>,
+    pub collectors: Vec<Arc<dyn MetricsCollector>>,
+    pub info: ServiceInfo,
+}
+
+/// 服务信息
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ServiceInfo {
+    pub name: String,
+    pub version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_commit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build_time: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rust_version: Option<String>,
+    pub profile: String,
+}
+
+/// 构建 actuator 路由
+///
+/// 端点:
+/// - GET /actuator/health           → 聚合状态 (JSON)
+/// - GET /actuator/health/liveness  → 进程存活 (JSON)
+/// - GET /actuator/health/readiness → 可接流量 (JSON)
+/// - GET /actuator/info             → 服务信息 (JSON)
+/// - GET /actuator/metrics          → Prometheus exposition (text/plain)
+pub fn actuator_routes(state: ActuatorState) -> Router {
+    Router::new()
+        .route("/actuator/health", get(health_handler))
+        .route("/actuator/health/liveness", get(liveness_handler))
+        .route("/actuator/health/readiness", get(readiness_handler))
+        .route("/actuator/info", get(info_handler))
+        .route("/actuator/metrics", get(metrics_handler))
+        .with_state(state)
+}
+```
+
+### 4.4 Endpoint Response Formats
+
+#### `GET /actuator/health`
+
+```json
+{
+  "status": "UP",
+  "components": {
+    "db": {
+      "status": "UP",
+      "details": { "database": "PostgreSQL", "latency_ms": 2 }
+    },
+    "nacos": {
+      "status": "UP",
+      "details": { "server": "127.0.0.1:9848", "protocol": "gRPC" }
+    },
+    "diskSpace": {
+      "status": "UP",
+      "details": { "total_bytes": 500107862016, "free_bytes": 387842883584 }
+    }
+  }
+}
+```
+
+#### `GET /actuator/health/liveness`
+
+```json
+{ "status": "UP" }
+```
+
+Always `UP` if the process is running. Kubernetes uses this to decide whether to **restart** the container.
+
+#### `GET /actuator/health/readiness`
+
+```json
+{ "status": "UP" }
+```
+
+Aggregates only indicators where `contributes_to_readiness() == true`. Kubernetes uses this to decide whether to **route traffic** to the container.
+
+During shutdown: readiness returns `OUT_OF_SERVICE` → gateway stops routing → drain period → deregister → exit.
+
+#### `GET /actuator/info`
+
+```json
+{
+  "name": "order-service-rust",
+  "version": "4.1.1",
+  "git_commit": "a1b2c3d",
+  "build_time": "2026-07-20T12:00:00Z",
+  "rust_version": "1.87.0",
+  "profile": "release"
+}
+```
+
+#### `GET /actuator/metrics`
+
+Content-Type: `text/plain; version=0.0.4; charset=utf-8`
+
+```
+# HELP teaql_http_requests_total Total HTTP requests
+# TYPE teaql_http_requests_total counter
+teaql_http_requests_total{method="GET",path="/api/orders"} 1234
+
+# HELP teaql_db_pool_active Active database connections
+# TYPE teaql_db_pool_active gauge
+teaql_db_pool_active 5
+
+# HELP teaql_db_query_duration_seconds Database query duration
+# TYPE teaql_db_query_duration_seconds histogram
+teaql_db_query_duration_seconds_bucket{le="0.01"} 100
+teaql_db_query_duration_seconds_bucket{le="0.1"} 150
+teaql_db_query_duration_seconds_bucket{le="1.0"} 155
+teaql_db_query_duration_seconds_sum 12.5
+teaql_db_query_duration_seconds_count 155
+```
+
+---
+
+## 5. `teaql-cloud-nacos` — Nacos v2 gRPC Implementation
+
+### 5.1 Strategy: Wrap `nacos-sdk` crate
+
+已有官方 Rust SDK: [`nacos-sdk`](https://crates.io/crates/nacos-sdk) v0.8，原生支持 Nacos v2 gRPC 协议。
+
+**我们不重写 gRPC 协议，而是封装 `nacos-sdk` 来实现 `teaql-cloud-core` 的 trait。**
+
+Nacos v2 gRPC 相比 v1 HTTP 的关键优势:
+- **长连接**: 连接本身就是心跳，无需主动 beat
+- **服务端推送**: 服务/配置变更即时推送，无需 long polling
+- **性能**: gRPC binary protocol，远优于 HTTP JSON
+- **未来兼容**: Nacos 3.x 将移除 HTTP API，gRPC 成为唯一协议
+
+### 5.2 Directory Structure
+
+```
+teaql-cloud-nacos/
+├── Cargo.toml
+└── src/
+    ├── lib.rs              # NacosCloud 统一入口
+    ├── config.rs           # NacosConfig 连接配置
+    ├── registry.rs         # impl ServiceRegistry
+    ├── discovery.rs        # impl ServiceDiscovery
+    ├── config_source.rs    # impl ConfigSource
+    ├── health.rs           # impl HealthIndicator
+    └── metrics.rs          # impl MetricsCollector
+```
+
+### 5.3 `Cargo.toml`
+
+```toml
+[package]
+name = "teaql-cloud-nacos"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+teaql-cloud-core = { workspace = true }
+nacos-sdk = "=0.8"
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = "1"
+```
+
+### 5.4 `NacosCloud` — 统一入口
+
+```rust
+use nacos_sdk::api::config::{ConfigService, ConfigServiceBuilder};
+use nacos_sdk::api::naming::{NamingService, NamingServiceBuilder};
+use nacos_sdk::api::props::ClientProps;
+use teaql_cloud_core::CloudError;
+
+/// Nacos 连接配置
+#[derive(Debug, Clone)]
+pub struct NacosConfig {
+    /// Nacos server address (e.g. "127.0.0.1:8848")
+    /// SDK 会自动推算 gRPC 端口 (offset +1000 → 9848)
+    pub server_addr: String,
+    pub namespace: Option<String>,
+    pub app_name: Option<String>,
+    pub auth: Option<NacosAuth>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NacosAuth {
+    pub username: String,
+    pub password: String,
+}
+
+/// Nacos 统一客户端
+///
+/// 内部持有 nacos-sdk 的 NamingService + ConfigService
+/// 对外暴露 teaql-cloud-core 的 trait 实现
+pub struct NacosCloud {
+    naming_service: Arc<dyn NamingService>,
+    config_service: Arc<dyn ConfigService>,
+    config: NacosConfig,
+}
+
+impl NacosCloud {
+    pub async fn new(config: NacosConfig) -> Result<Self, CloudError> {
+        let mut props = ClientProps::new()
+            .server_addr(&config.server_addr);
+
+        if let Some(ns) = &config.namespace {
+            props = props.namespace(ns);
+        }
+        if let Some(app) = &config.app_name {
+            props = props.app_name(app);
+        }
+
+        let mut naming_builder = NamingServiceBuilder::new(props.clone());
+        let mut config_builder = ConfigServiceBuilder::new(props);
+
+        if let Some(auth) = &config.auth {
+            naming_builder = naming_builder
+                .enable_auth_plugin_http()
+                .auth_username(auth.username.clone())
+                .auth_password(auth.password.clone());
+            config_builder = config_builder
+                .enable_auth_plugin_http()
+                .auth_username(auth.username.clone())
+                .auth_password(auth.password.clone());
+        }
+
+        let naming_service = naming_builder.build()
+            .map_err(|e| CloudError::Registration(e.to_string()))?;
+        let config_service = config_builder.build()
+            .await
+            .map_err(|e| CloudError::Config(e.to_string()))?;
+
+        Ok(Self {
+            naming_service: Arc::new(naming_service),
+            config_service: Arc::new(config_service),
+            config,
+        })
+    }
+
+    /// 返回 ServiceRegistry 实现
+    pub fn registry(&self) -> NacosServiceRegistry { ... }
+
+    /// 返回 ServiceDiscovery 实现
+    pub fn discovery(&self) -> NacosServiceDiscovery { ... }
+
+    /// 返回 ConfigSource 实现
+    pub fn config_source(&self) -> NacosConfigSource { ... }
+
+    /// 返回 HealthIndicator 实现
+    pub fn health_indicator(&self) -> NacosHealthIndicator { ... }
+
+    /// 返回 MetricsCollector 实现
+    pub fn metrics_collector(&self) -> NacosMetricsCollector { ... }
+}
+```
+
+### 5.5 Nacos v2 gRPC API Mapping
+
+| teaql-cloud-core trait | nacos-sdk method | Nacos v2 protocol |
+|------------------------|------------------|-------------------|
+| `ServiceRegistry::register()` | `naming_service.register_instance()` | gRPC `InstanceRequest` |
+| `ServiceRegistry::deregister()` | `naming_service.deregister_instance()` | gRPC `InstanceRequest` |
+| `ServiceRegistry::heartbeat()` | **no-op** (gRPC 长连接即心跳) | 连接自动维持 |
+| `ServiceRegistry::heartbeat_interval()` | 返回 `None` | — |
+| `ServiceDiscovery::get_instances()` | `naming_service.get_all_instances()` | gRPC `ServiceQueryRequest` |
+| `ServiceDiscovery::subscribe()` | `naming_service.subscribe()` | gRPC 服务端推送 |
+| `ConfigSource::get_config()` | `config_service.get_config()` | gRPC `ConfigQueryRequest` |
+| `ConfigSource::publish_config()` | `config_service.publish_config()` | gRPC `ConfigPublishRequest` |
+| `ConfigSource::watch()` | `config_service.add_listener()` | gRPC 服务端推送 |
+
+> **Note**: Nacos v2 gRPC 长连接本身充当心跳，连接断开即被 server 标记为不健康。
+> 因此 `heartbeat_interval()` 返回 `None`，`heartbeat()` 为空操作。
+
+---
+
+## 6. Graceful Shutdown Flow
+
+```
+正常运行                  Ctrl+C / SIGTERM
+    │                          │
+    │                          ▼
+    │                  ┌───────────────┐
+    │                  │ 1. readiness  │
+    │                  │    → OUT_OF   │
+    │                  │    SERVICE    │
+    │                  └───────┬───────┘
+    │                          │  ← 网关/LB 停止路由新请求
+    │                          ▼
+    │                  ┌───────────────┐
+    │                  │ 2. deregister │
+    │                  │  from Nacos   │
+    │                  └───────┬───────┘
+    │                          │
+    │                          ▼
+    │                  ┌───────────────┐
+    │                  │ 3. drain      │
+    │                  │  等待在途请求  │
+    │                  │  (可配置超时)  │
+    │                  └───────┬───────┘
+    │                          │
+    │                          ▼
+    │                  ┌───────────────┐
+    │                  │ 4. 关闭 gRPC  │
+    │                  │  连接, 退出   │
+    │                  └───────────────┘
+```
+
+### Application-level Integration
+
+```rust
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // ... setup nacos, module, routes ...
+
+    let lifecycle = ServiceLifecycle::start(
+        nacos.registry(),
+        instance,
+    ).await?;
+
+    let shutdown_rx = lifecycle.shutdown_receiver();
+
+    let listener = TcpListener::bind("0.0.0.0:8080").await?;
+
+    // Axum serve with graceful shutdown
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async move {
+            wait_for_shutdown_signal().await;
+            // 给 gateway 时间感知 readiness 变化
+            tokio::time::sleep(Duration::from_secs(3)).await;
+        })
+        .await?;
+
+    // Axum has drained — now clean up
+    lifecycle.shutdown().await?;
+
+    Ok(())
+}
+```
+
+---
+
+## 7. Workspace Changes
+
+```toml
+# Cargo.toml (workspace root) — 新增 members
+[workspace]
+members = [
+    # existing...
+    "teaql-cloud-core",
+    "teaql-cloud-actuator",
+    "teaql-cloud-nacos",
+]
+
+[workspace.dependencies]
+# existing...
+teaql-cloud-core = { path = "teaql-cloud-core", version = "0.1.0" }
+teaql-cloud-actuator = { path = "teaql-cloud-actuator", version = "0.1.0" }
+teaql-cloud-nacos = { path = "teaql-cloud-nacos", version = "0.1.0" }
+teaql-cloud-starter = { path = "teaql-cloud-starter", version = "0.1.0" }
+```
+
+---
+
+## 8. Implementation Priority
+
+| Phase | Task | Scope |
+|-------|------|-------|
+| **P0** | `teaql-cloud-core` | 所有 trait + model + error + lifecycle |
+| **P1** | `teaql-cloud-actuator` | health (含 liveness/readiness) + info + metrics (pull + push gateway) |
+| **P2** | `teaql-cloud-nacos` | registry + discovery + config (wrap nacos-sdk `=0.8`) |
+| **P3** | `teaql-cloud-starter` | 一行启动 convenience API |
+| **P4** | Integration test | 完整启动流程 + graceful shutdown 测试 |
+
+---
+
+## 9. Resolved Questions
+
+- [x] **`nacos-sdk` 版本策略** → **Pin 到 `=0.8`**，完全锁死版本，避免 0.x 阶段的 breaking change
+- [x] **Prometheus push gateway** → **两种都要**。pull 模式是默认（`/actuator/metrics`），同时支持 push gateway 模式用于短生命周期任务或防火墙受限场景
+- [x] **`teaql-cloud-starter`** → **需要**。开发者体验很重要，提供一个 crate 一行启动所有 cloud 能力
+
+---
+
+## 10. `teaql-cloud-starter` — One-line Bootstrap
+
+### 10.1 定位
+
+类似 Spring Boot Starter 的概念，把 Nacos 连接 + 服务注册 + Actuator 路由 + Graceful Shutdown 全部打包。
+
+### 10.2 Directory Structure
+
+```
+teaql-cloud-starter/
+├── Cargo.toml
+└── src/
+    └── lib.rs
+```
+
+### 10.3 `Cargo.toml`
+
+```toml
+[package]
+name = "teaql-cloud-starter"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+teaql-cloud-core = { workspace = true }
+teaql-cloud-actuator = { workspace = true }
+teaql-cloud-nacos = { workspace = true }
+tokio = { workspace = true }
+axum = { version = "0.7" }
+```
+
+### 10.4 Usage
+
+```rust
+use teaql_cloud_starter::CloudApp;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    CloudApp::new()
+        .nacos("127.0.0.1:8848")
+        .namespace("production")
+        .service_name("order-service-rust")
+        .port(8080)
+        .health_indicator(DatabaseHealthIndicator::new(&db_pool))
+        .health_indicator(DiskSpaceHealthIndicator::default())
+        .metrics_collector(HttpMetricsCollector::new())
+        .routes(business_routes())
+        .start()
+        .await?;
+    // Graceful shutdown is handled automatically
+    Ok(())
+}
+```
+
+`CloudApp::start()` 内部执行:
+1. 连接 Nacos (gRPC)
+2. 拉取配置
+3. 注册服务实例
+4. 组装 Axum Router (业务路由 + actuator 路由)
+5. 绑定端口，启动 HTTP 服务
+6. 监听 SIGINT/SIGTERM → graceful shutdown → deregister

--- a/teaql-cloud-core/Cargo.toml
+++ b/teaql-cloud-core/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "teaql-cloud-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Core trait definitions and shared models for TeaQL cloud integration"
+repository.workspace = true
+readme = "README.md"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = "1"
+thiserror = { workspace = true }
+async-trait = { workspace = true }
+tokio = { version = "1", features = ["sync", "signal", "time", "rt", "macros"] }

--- a/teaql-cloud-core/src/config.rs
+++ b/teaql-cloud-core/src/config.rs
@@ -1,0 +1,122 @@
+use async_trait::async_trait;
+
+use crate::CloudError;
+use crate::model::ConfigId;
+
+/// Handle to cancel a configuration watch.
+///
+/// Call `unwatch()` to stop receiving change notifications.
+pub struct WatchHandle {
+    cancel: Box<dyn FnOnce() + Send>,
+}
+
+impl WatchHandle {
+    pub fn new(cancel: impl FnOnce() + Send + 'static) -> Self {
+        Self {
+            cancel: Box::new(cancel),
+        }
+    }
+
+    /// Cancel the watch.
+    pub fn unwatch(self) {
+        (self.cancel)();
+    }
+}
+
+/// Configuration source abstraction.
+///
+/// Change notification mechanisms vary by backend:
+/// - Nacos v2: gRPC Push (server-initiated)
+/// - etcd: gRPC Watch stream
+/// - Consul: Blocking Query (HTTP long poll)
+/// - Apollo: Long Polling + local cache
+///
+/// All are unified under the callback-based `watch()` API.
+#[async_trait]
+pub trait ConfigSource: Send + Sync {
+    /// Get configuration content (returns raw string, caller parses as YAML/TOML/JSON).
+    async fn get_config(&self, config_id: &ConfigId) -> Result<String, CloudError>;
+
+    /// Publish configuration content.
+    ///
+    /// Not all backends support this operation.
+    async fn publish_config(&self, config_id: &ConfigId, content: &str) -> Result<(), CloudError>;
+
+    /// Watch for configuration changes.
+    ///
+    /// The callback is invoked with the new configuration content whenever
+    /// a change is detected. Returns a handle to cancel the watch.
+    async fn watch(
+        &self,
+        config_id: &ConfigId,
+        callback: Box<dyn Fn(String) + Send + Sync>,
+    ) -> Result<WatchHandle, CloudError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    struct MockConfigSource {
+        content: String,
+    }
+
+    #[async_trait]
+    impl ConfigSource for MockConfigSource {
+        async fn get_config(&self, _config_id: &ConfigId) -> Result<String, CloudError> {
+            Ok(self.content.clone())
+        }
+
+        async fn publish_config(
+            &self,
+            _config_id: &ConfigId,
+            _content: &str,
+        ) -> Result<(), CloudError> {
+            Ok(())
+        }
+
+        async fn watch(
+            &self,
+            _config_id: &ConfigId,
+            _callback: Box<dyn Fn(String) + Send + Sync>,
+        ) -> Result<WatchHandle, CloudError> {
+            Ok(WatchHandle::new(|| {}))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_config() {
+        let source = MockConfigSource {
+            content: "server:\n  port: 8080".to_string(),
+        };
+        let config_id = ConfigId::new("app.yaml", "DEFAULT_GROUP");
+        let content = source.get_config(&config_id).await.unwrap();
+        assert!(content.contains("port: 8080"));
+    }
+
+    #[tokio::test]
+    async fn test_publish_config() {
+        let source = MockConfigSource {
+            content: String::new(),
+        };
+        let config_id = ConfigId::new("app.yaml", "DEFAULT_GROUP");
+        assert!(
+            source
+                .publish_config(&config_id, "new content")
+                .await
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_watch_handle_unwatch() {
+        let cancelled = Arc::new(Mutex::new(false));
+        let cancelled_clone = cancelled.clone();
+        let handle = WatchHandle::new(move || {
+            *cancelled_clone.lock().unwrap() = true;
+        });
+        handle.unwatch();
+        assert!(*cancelled.lock().unwrap());
+    }
+}

--- a/teaql-cloud-core/src/discovery.rs
+++ b/teaql-cloud-core/src/discovery.rs
@@ -1,0 +1,136 @@
+use async_trait::async_trait;
+
+use crate::{CloudError, ServiceGroup, ServiceInstance};
+
+/// Service change event — pushed when instances are added, removed, or updated.
+#[derive(Debug, Clone)]
+pub struct ServiceChangeEvent {
+    pub service_name: String,
+    pub instances: Vec<ServiceInstance>,
+}
+
+/// Handle to cancel a service subscription.
+///
+/// Call `unsubscribe()` to stop receiving change events.
+pub struct SubscriptionHandle {
+    cancel: Box<dyn FnOnce() + Send>,
+}
+
+impl SubscriptionHandle {
+    pub fn new(cancel: impl FnOnce() + Send + 'static) -> Self {
+        Self {
+            cancel: Box::new(cancel),
+        }
+    }
+
+    /// Cancel the subscription.
+    pub fn unsubscribe(self) {
+        (self.cancel)();
+    }
+}
+
+/// Service discovery capability.
+///
+/// Push mechanisms vary by backend:
+/// - Nacos v2: gRPC server-side push (near-instant)
+/// - etcd: gRPC Watch stream
+/// - Consul: Blocking Query (long polling)
+///
+/// All are unified under the callback-based `subscribe()` API.
+#[async_trait]
+pub trait ServiceDiscovery: Send + Sync {
+    /// Get healthy service instances (one-shot pull).
+    async fn get_instances(
+        &self,
+        service_name: &str,
+        group: &ServiceGroup,
+    ) -> Result<Vec<ServiceInstance>, CloudError>;
+
+    /// Get all instances including unhealthy ones.
+    ///
+    /// Default implementation delegates to `get_instances()`.
+    async fn get_all_instances(
+        &self,
+        service_name: &str,
+        group: &ServiceGroup,
+    ) -> Result<Vec<ServiceInstance>, CloudError> {
+        self.get_instances(service_name, group).await
+    }
+
+    /// Subscribe to service instance changes.
+    ///
+    /// The callback is invoked whenever instances are added, removed, or updated.
+    /// Returns a handle that can be used to cancel the subscription.
+    async fn subscribe(
+        &self,
+        service_name: &str,
+        group: &ServiceGroup,
+        callback: Box<dyn Fn(ServiceChangeEvent) + Send + Sync>,
+    ) -> Result<SubscriptionHandle, CloudError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    struct MockDiscovery {
+        instances: Vec<ServiceInstance>,
+    }
+
+    #[async_trait]
+    impl ServiceDiscovery for MockDiscovery {
+        async fn get_instances(
+            &self,
+            _service_name: &str,
+            _group: &ServiceGroup,
+        ) -> Result<Vec<ServiceInstance>, CloudError> {
+            Ok(self.instances.clone())
+        }
+
+        async fn subscribe(
+            &self,
+            _service_name: &str,
+            _group: &ServiceGroup,
+            _callback: Box<dyn Fn(ServiceChangeEvent) + Send + Sync>,
+        ) -> Result<SubscriptionHandle, CloudError> {
+            Ok(SubscriptionHandle::new(|| {}))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_instances() {
+        let discovery = MockDiscovery {
+            instances: vec![
+                ServiceInstance::new("order-svc", "10.0.0.1", 8080),
+                ServiceInstance::new("order-svc", "10.0.0.2", 8080),
+            ],
+        };
+
+        let group = ServiceGroup::new();
+        let instances = discovery.get_instances("order-svc", &group).await.unwrap();
+        assert_eq!(instances.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_get_all_instances_defaults_to_get_instances() {
+        let discovery = MockDiscovery {
+            instances: vec![ServiceInstance::new("svc", "10.0.0.1", 8080)],
+        };
+
+        let group = ServiceGroup::new();
+        let all = discovery.get_all_instances("svc", &group).await.unwrap();
+        assert_eq!(all.len(), 1);
+    }
+
+    #[test]
+    fn test_subscription_handle_unsubscribe() {
+        let cancelled = Arc::new(Mutex::new(false));
+        let cancelled_clone = cancelled.clone();
+        let handle = SubscriptionHandle::new(move || {
+            *cancelled_clone.lock().unwrap() = true;
+        });
+        handle.unsubscribe();
+        assert!(*cancelled.lock().unwrap());
+    }
+}

--- a/teaql-cloud-core/src/error.rs
+++ b/teaql-cloud-core/src/error.rs
@@ -1,0 +1,79 @@
+use thiserror::Error;
+
+/// Unified error type for all cloud integration operations.
+#[derive(Error, Debug)]
+pub enum CloudError {
+    #[error("Service discovery error: {0}")]
+    Discovery(String),
+
+    #[error("Service registration error: {0}")]
+    Registration(String),
+
+    #[error("Config error: {0}")]
+    Config(String),
+
+    #[error("Health check error: {0}")]
+    Health(String),
+
+    #[error("Network error: {source}")]
+    Network {
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[error("Serialization error: {0}")]
+    Serialization(String),
+
+    #[error("Timeout after {duration:?}")]
+    Timeout { duration: std::time::Duration },
+
+    #[error("Shutdown in progress")]
+    ShuttingDown,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_display() {
+        let err = CloudError::Discovery("service not found".to_string());
+        assert_eq!(
+            err.to_string(),
+            "Service discovery error: service not found"
+        );
+
+        let err = CloudError::Registration("connection refused".to_string());
+        assert_eq!(
+            err.to_string(),
+            "Service registration error: connection refused"
+        );
+
+        let err = CloudError::Config("invalid config format".to_string());
+        assert_eq!(err.to_string(), "Config error: invalid config format");
+
+        let err = CloudError::Health("db unreachable".to_string());
+        assert_eq!(err.to_string(), "Health check error: db unreachable");
+
+        let err = CloudError::Serialization("invalid json".to_string());
+        assert_eq!(err.to_string(), "Serialization error: invalid json");
+
+        let err = CloudError::Timeout {
+            duration: std::time::Duration::from_secs(30),
+        };
+        assert!(err.to_string().contains("30"));
+
+        let err = CloudError::ShuttingDown;
+        assert_eq!(err.to_string(), "Shutdown in progress");
+    }
+
+    #[test]
+    fn test_network_error_source() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "refused");
+        let err = CloudError::Network {
+            source: Box::new(io_err),
+        };
+        assert!(err.to_string().contains("Network error"));
+        assert!(std::error::Error::source(&err).is_some());
+    }
+}

--- a/teaql-cloud-core/src/health.rs
+++ b/teaql-cloud-core/src/health.rs
@@ -1,0 +1,226 @@
+use async_trait::async_trait;
+use serde::Serialize;
+use std::collections::HashMap;
+
+/// Health status — compatible with Spring Boot Actuator output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum HealthStatus {
+    #[serde(rename = "UP")]
+    Up,
+    #[serde(rename = "DOWN")]
+    Down,
+    #[serde(rename = "UNKNOWN")]
+    Unknown,
+    /// Service is starting up: liveness = true, readiness = false.
+    #[serde(rename = "OUT_OF_SERVICE")]
+    OutOfService,
+}
+
+impl HealthStatus {
+    /// Aggregate multiple statuses:
+    /// - Any `Down` → `Down`
+    /// - Any `OutOfService` → `OutOfService`
+    /// - All `Up` → `Up`
+    /// - Otherwise → `Unknown`
+    pub fn aggregate(statuses: &[HealthStatus]) -> HealthStatus {
+        if statuses.is_empty() {
+            return HealthStatus::Unknown;
+        }
+        if statuses.contains(&HealthStatus::Down) {
+            HealthStatus::Down
+        } else if statuses.contains(&HealthStatus::OutOfService) {
+            HealthStatus::OutOfService
+        } else if statuses.iter().all(|s| *s == HealthStatus::Up) {
+            HealthStatus::Up
+        } else {
+            HealthStatus::Unknown
+        }
+    }
+}
+
+/// Health detail for a single component.
+#[derive(Debug, Clone, Serialize)]
+pub struct HealthDetail {
+    pub status: HealthStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<serde_json::Value>,
+}
+
+impl HealthDetail {
+    /// Component is healthy with no additional details.
+    pub fn up() -> Self {
+        Self {
+            status: HealthStatus::Up,
+            details: None,
+        }
+    }
+
+    /// Component is down with an error reason.
+    pub fn down(reason: impl Into<String>) -> Self {
+        Self {
+            status: HealthStatus::Down,
+            details: Some(serde_json::json!({ "error": reason.into() })),
+        }
+    }
+
+    /// Component is healthy with additional diagnostic details.
+    pub fn up_with_details(details: serde_json::Value) -> Self {
+        Self {
+            status: HealthStatus::Up,
+            details: Some(details),
+        }
+    }
+}
+
+/// Health indicator — each component to be checked implements this trait.
+///
+/// Built-in implementations (in actuator crate):
+/// - `DiskSpaceHealthIndicator`
+///
+/// Backend-provided implementations:
+/// - `NacosHealthIndicator` (in `teaql-cloud-nacos`)
+#[async_trait]
+pub trait HealthIndicator: Send + Sync {
+    /// Component name (e.g. "db", "nacos", "diskSpace").
+    fn name(&self) -> &str;
+
+    /// Perform the health check.
+    async fn check(&self) -> HealthDetail;
+
+    /// Whether this indicator contributes to readiness determination.
+    ///
+    /// Set to `false` for components that should not affect traffic routing
+    /// (e.g. optional caches).
+    fn contributes_to_readiness(&self) -> bool {
+        true
+    }
+}
+
+/// Aggregated health response — compatible with Spring Boot Actuator format.
+#[derive(Debug, Clone, Serialize)]
+pub struct HealthResponse {
+    pub status: HealthStatus,
+    pub components: HashMap<String, HealthDetail>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_health_status_aggregate_all_up() {
+        let statuses = vec![HealthStatus::Up, HealthStatus::Up, HealthStatus::Up];
+        assert_eq!(HealthStatus::aggregate(&statuses), HealthStatus::Up);
+    }
+
+    #[test]
+    fn test_health_status_aggregate_any_down() {
+        let statuses = vec![HealthStatus::Up, HealthStatus::Down, HealthStatus::Up];
+        assert_eq!(HealthStatus::aggregate(&statuses), HealthStatus::Down);
+    }
+
+    #[test]
+    fn test_health_status_aggregate_out_of_service() {
+        let statuses = vec![HealthStatus::Up, HealthStatus::OutOfService];
+        assert_eq!(
+            HealthStatus::aggregate(&statuses),
+            HealthStatus::OutOfService
+        );
+    }
+
+    #[test]
+    fn test_health_status_aggregate_down_beats_out_of_service() {
+        let statuses = vec![HealthStatus::Down, HealthStatus::OutOfService];
+        assert_eq!(HealthStatus::aggregate(&statuses), HealthStatus::Down);
+    }
+
+    #[test]
+    fn test_health_status_aggregate_empty() {
+        assert_eq!(HealthStatus::aggregate(&[]), HealthStatus::Unknown);
+    }
+
+    #[test]
+    fn test_health_status_aggregate_with_unknown() {
+        let statuses = vec![HealthStatus::Up, HealthStatus::Unknown];
+        assert_eq!(HealthStatus::aggregate(&statuses), HealthStatus::Unknown);
+    }
+
+    #[test]
+    fn test_health_detail_up() {
+        let detail = HealthDetail::up();
+        assert_eq!(detail.status, HealthStatus::Up);
+        assert!(detail.details.is_none());
+    }
+
+    #[test]
+    fn test_health_detail_down() {
+        let detail = HealthDetail::down("connection refused");
+        assert_eq!(detail.status, HealthStatus::Down);
+        let details = detail.details.unwrap();
+        assert_eq!(details["error"], "connection refused");
+    }
+
+    #[test]
+    fn test_health_detail_up_with_details() {
+        let detail = HealthDetail::up_with_details(serde_json::json!({
+            "database": "PostgreSQL",
+            "latency_ms": 2
+        }));
+        assert_eq!(detail.status, HealthStatus::Up);
+        let details = detail.details.unwrap();
+        assert_eq!(details["database"], "PostgreSQL");
+        assert_eq!(details["latency_ms"], 2);
+    }
+
+    #[test]
+    fn test_health_response_serialization() {
+        let mut components = HashMap::new();
+        components.insert("db".to_string(), HealthDetail::up());
+        components.insert("nacos".to_string(), HealthDetail::down("unreachable"));
+
+        let response = HealthResponse {
+            status: HealthStatus::Down,
+            components,
+        };
+
+        let json = serde_json::to_value(&response).unwrap();
+        assert_eq!(json["status"], "DOWN");
+        assert_eq!(json["components"]["db"]["status"], "UP");
+        assert_eq!(json["components"]["nacos"]["status"], "DOWN");
+    }
+
+    #[test]
+    fn test_health_status_serde() {
+        assert_eq!(serde_json::to_string(&HealthStatus::Up).unwrap(), "\"UP\"");
+        assert_eq!(
+            serde_json::to_string(&HealthStatus::Down).unwrap(),
+            "\"DOWN\""
+        );
+        assert_eq!(
+            serde_json::to_string(&HealthStatus::OutOfService).unwrap(),
+            "\"OUT_OF_SERVICE\""
+        );
+    }
+
+    struct AlwaysUpIndicator;
+
+    #[async_trait]
+    impl HealthIndicator for AlwaysUpIndicator {
+        fn name(&self) -> &str {
+            "always_up"
+        }
+
+        async fn check(&self) -> HealthDetail {
+            HealthDetail::up()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_health_indicator_trait() {
+        let indicator = AlwaysUpIndicator;
+        assert_eq!(indicator.name(), "always_up");
+        assert!(indicator.contributes_to_readiness());
+        let detail = indicator.check().await;
+        assert_eq!(detail.status, HealthStatus::Up);
+    }
+}

--- a/teaql-cloud-core/src/lib.rs
+++ b/teaql-cloud-core/src/lib.rs
@@ -1,0 +1,46 @@
+//! # teaql-cloud-core
+//!
+//! Core trait definitions and shared models for TeaQL cloud integration.
+//!
+//! This crate provides the abstraction layer for embedding Rust services
+//! into Java microservice architectures. It defines traits for:
+//!
+//! - **Service Registry** — register/deregister/heartbeat
+//! - **Service Discovery** — instance lookup and change subscription
+//! - **Config Source** — configuration retrieval and watch
+//! - **Health Indicator** — health check with Spring Boot Actuator compatibility
+//! - **Metrics Collector** — metrics with Prometheus exposition format
+//! - **Service Lifecycle** — graceful startup and shutdown
+//!
+//! ## Independence
+//!
+//! This crate does **not** depend on `teaql-runtime` or `teaql-core`.
+//! It can be used standalone in any Rust service, not just TeaQL-based ones.
+//!
+//! ## Backend Implementations
+//!
+//! The traits defined here are implemented by backend-specific crates:
+//!
+//! - `teaql-cloud-nacos` — Nacos v2 gRPC
+//! - `teaql-cloud-consul` — Consul (future)
+//! - `teaql-cloud-etcd` — etcd (future)
+//! - `teaql-cloud-k8s` — Kubernetes (future)
+
+mod config;
+mod discovery;
+mod error;
+mod health;
+mod lifecycle;
+mod metrics;
+mod model;
+mod registry;
+
+// Re-export all public types
+pub use config::{ConfigSource, WatchHandle};
+pub use discovery::{ServiceChangeEvent, ServiceDiscovery, SubscriptionHandle};
+pub use error::CloudError;
+pub use health::{HealthDetail, HealthIndicator, HealthResponse, HealthStatus};
+pub use lifecycle::{ServiceLifecycle, wait_for_shutdown_signal};
+pub use metrics::{Metric, MetricValue, MetricsCollector, to_prometheus_exposition};
+pub use model::{ConfigId, ServiceGroup, ServiceInstance};
+pub use registry::ServiceRegistry;

--- a/teaql-cloud-core/src/lifecycle.rs
+++ b/teaql-cloud-core/src/lifecycle.rs
@@ -1,0 +1,265 @@
+use std::sync::Arc;
+
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+
+use crate::{CloudError, ServiceInstance, ServiceRegistry};
+
+/// Service lifecycle guard.
+///
+/// Manages the full service registration lifecycle:
+/// `register → heartbeat loop → (shutdown signal) → deregister`
+///
+/// # Shutdown flow
+///
+/// 1. Call `shutdown()` or drop the guard
+/// 2. Heartbeat loop stops
+/// 3. Service is deregistered from the registry
+///
+/// Integrate with Axum for graceful shutdown:
+///
+/// ```ignore
+/// let lifecycle = ServiceLifecycle::start(registry, instance).await?;
+/// let mut shutdown_rx = lifecycle.shutdown_receiver();
+///
+/// axum::serve(listener, app)
+///     .with_graceful_shutdown(async move {
+///         wait_for_shutdown_signal().await;
+///     })
+///     .await?;
+///
+/// lifecycle.shutdown().await?;
+/// ```
+pub struct ServiceLifecycle {
+    shutdown_tx: watch::Sender<bool>,
+    heartbeat_handle: JoinHandle<()>,
+    instance: ServiceInstance,
+    registry: Arc<dyn ServiceRegistry>,
+}
+
+impl ServiceLifecycle {
+    /// Start the service lifecycle: register the instance and begin the heartbeat loop.
+    pub async fn start(
+        registry: Arc<dyn ServiceRegistry>,
+        instance: ServiceInstance,
+    ) -> Result<Self, CloudError> {
+        // 1. Register the service instance
+        registry.register(&instance).await?;
+
+        // 2. Start heartbeat loop (if the backend requires it)
+        let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+        let heartbeat_handle = {
+            let registry = registry.clone();
+            let instance = instance.clone();
+
+            tokio::spawn(async move {
+                let interval = registry.heartbeat_interval();
+                if let Some(interval) = interval {
+                    loop {
+                        tokio::select! {
+                            _ = tokio::time::sleep(interval) => {
+                                let _ = registry.heartbeat(&instance).await;
+                            }
+                            _ = shutdown_rx.changed() => {
+                                break;
+                            }
+                        }
+                    }
+                } else {
+                    // No heartbeat needed (e.g. Nacos v2 gRPC),
+                    // just wait for shutdown signal
+                    let _ = shutdown_rx.changed().await;
+                }
+            })
+        };
+
+        Ok(Self {
+            shutdown_tx,
+            heartbeat_handle,
+            instance,
+            registry,
+        })
+    }
+
+    /// Get a shutdown receiver for integration with Axum's graceful shutdown.
+    pub fn shutdown_receiver(&self) -> watch::Receiver<bool> {
+        self.shutdown_tx.subscribe()
+    }
+
+    /// Trigger a graceful shutdown:
+    /// 1. Stop the heartbeat loop
+    /// 2. Deregister from the service registry
+    pub async fn shutdown(self) -> Result<(), CloudError> {
+        // Signal heartbeat to stop
+        let _ = self.shutdown_tx.send(true);
+
+        // Wait for heartbeat task to finish
+        let _ = self.heartbeat_handle.await;
+
+        // Deregister from service registry
+        self.registry.deregister(&self.instance).await?;
+
+        Ok(())
+    }
+}
+
+/// Wait for a system shutdown signal (SIGINT or SIGTERM).
+///
+/// This function completes when either Ctrl+C is pressed or a SIGTERM
+/// is received. Use it with Axum's `with_graceful_shutdown()`.
+///
+/// # Example
+///
+/// ```ignore
+/// axum::serve(listener, app)
+///     .with_graceful_shutdown(wait_for_shutdown_signal())
+///     .await?;
+/// ```
+pub async fn wait_for_shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+    use std::time::Duration;
+
+    struct TrackingRegistry {
+        registered: AtomicBool,
+        deregistered: AtomicBool,
+        heartbeat_count: AtomicU32,
+        heartbeat_interval: Option<Duration>,
+    }
+
+    impl TrackingRegistry {
+        fn new(heartbeat_interval: Option<Duration>) -> Self {
+            Self {
+                registered: AtomicBool::new(false),
+                deregistered: AtomicBool::new(false),
+                heartbeat_count: AtomicU32::new(0),
+                heartbeat_interval,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ServiceRegistry for TrackingRegistry {
+        async fn register(&self, _instance: &ServiceInstance) -> Result<(), CloudError> {
+            self.registered.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn deregister(&self, _instance: &ServiceInstance) -> Result<(), CloudError> {
+            self.deregistered.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn heartbeat(&self, _instance: &ServiceInstance) -> Result<(), CloudError> {
+            self.heartbeat_count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        fn heartbeat_interval(&self) -> Option<Duration> {
+            self.heartbeat_interval
+        }
+    }
+
+    #[tokio::test]
+    async fn test_lifecycle_register_and_shutdown() {
+        let registry = Arc::new(TrackingRegistry::new(None));
+        let instance = ServiceInstance::new("test-svc", "127.0.0.1", 8080);
+
+        let lifecycle = ServiceLifecycle::start(registry.clone(), instance)
+            .await
+            .unwrap();
+
+        assert!(registry.registered.load(Ordering::SeqCst));
+        assert!(!registry.deregistered.load(Ordering::SeqCst));
+
+        lifecycle.shutdown().await.unwrap();
+
+        assert!(registry.deregistered.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn test_lifecycle_with_heartbeat() {
+        let registry = Arc::new(TrackingRegistry::new(Some(Duration::from_millis(50))));
+        let instance = ServiceInstance::new("test-svc", "127.0.0.1", 8080);
+
+        let lifecycle = ServiceLifecycle::start(registry.clone(), instance)
+            .await
+            .unwrap();
+
+        // Wait for a few heartbeats
+        tokio::time::sleep(Duration::from_millis(180)).await;
+
+        let count_before = registry.heartbeat_count.load(Ordering::SeqCst);
+        assert!(
+            count_before >= 2,
+            "Expected at least 2 heartbeats, got {count_before}"
+        );
+
+        lifecycle.shutdown().await.unwrap();
+
+        assert!(registry.deregistered.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn test_lifecycle_no_heartbeat_when_none() {
+        let registry = Arc::new(TrackingRegistry::new(None));
+        let instance = ServiceInstance::new("test-svc", "127.0.0.1", 8080);
+
+        let lifecycle = ServiceLifecycle::start(registry.clone(), instance)
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // No heartbeats should have been sent
+        assert_eq!(registry.heartbeat_count.load(Ordering::SeqCst), 0);
+
+        lifecycle.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_receiver() {
+        let registry = Arc::new(TrackingRegistry::new(None));
+        let instance = ServiceInstance::new("test-svc", "127.0.0.1", 8080);
+
+        let lifecycle = ServiceLifecycle::start(registry.clone(), instance)
+            .await
+            .unwrap();
+        let mut rx = lifecycle.shutdown_receiver();
+
+        // Not yet shut down
+        assert!(!*rx.borrow());
+
+        lifecycle.shutdown().await.unwrap();
+
+        // Receiver should now show shutdown
+        rx.changed().await.unwrap();
+        assert!(*rx.borrow());
+    }
+}

--- a/teaql-cloud-core/src/metrics.rs
+++ b/teaql-cloud-core/src/metrics.rs
@@ -1,0 +1,239 @@
+use async_trait::async_trait;
+
+/// Metric value types supported by Prometheus.
+#[derive(Debug, Clone)]
+pub enum MetricValue {
+    /// A monotonically increasing counter.
+    Counter(f64),
+    /// A value that can go up and down.
+    Gauge(f64),
+    /// A distribution of values with configurable buckets.
+    Histogram {
+        sum: f64,
+        count: u64,
+        buckets: Vec<(f64, u64)>,
+    },
+}
+
+/// A single metric with name, help text, labels, and value.
+#[derive(Debug, Clone)]
+pub struct Metric {
+    /// Metric name (e.g. "teaql_http_requests_total")
+    pub name: String,
+    /// Help text describing the metric
+    pub help: String,
+    /// Label key-value pairs
+    pub labels: Vec<(String, String)>,
+    /// The metric value
+    pub value: MetricValue,
+}
+
+impl Metric {
+    /// Create a counter metric.
+    pub fn counter(name: impl Into<String>, help: impl Into<String>, value: f64) -> Self {
+        Self {
+            name: name.into(),
+            help: help.into(),
+            labels: Vec::new(),
+            value: MetricValue::Counter(value),
+        }
+    }
+
+    /// Create a gauge metric.
+    pub fn gauge(name: impl Into<String>, help: impl Into<String>, value: f64) -> Self {
+        Self {
+            name: name.into(),
+            help: help.into(),
+            labels: Vec::new(),
+            value: MetricValue::Gauge(value),
+        }
+    }
+
+    /// Add a label to this metric.
+    pub fn with_label(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.labels.push((key.into(), value.into()));
+        self
+    }
+}
+
+/// Metrics collector trait.
+///
+/// Each component can contribute its own metrics:
+/// - Database: connection pool size, active connections, query latency
+/// - HTTP: request count, latency distribution
+/// - Nacos: heartbeat success/failure count
+#[async_trait]
+pub trait MetricsCollector: Send + Sync {
+    /// Collect a snapshot of current metrics.
+    async fn collect(&self) -> Vec<Metric>;
+}
+
+/// Format metrics as Prometheus exposition format.
+///
+/// Output conforms to the [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/).
+pub fn to_prometheus_exposition(metrics: &[Metric]) -> String {
+    let mut output = String::new();
+    for metric in metrics {
+        // # HELP line
+        output.push_str(&format!("# HELP {} {}\n", metric.name, metric.help));
+        // # TYPE line
+        let type_str = match &metric.value {
+            MetricValue::Counter(_) => "counter",
+            MetricValue::Gauge(_) => "gauge",
+            MetricValue::Histogram { .. } => "histogram",
+        };
+        output.push_str(&format!("# TYPE {} {}\n", metric.name, type_str));
+
+        // Labels string
+        let labels_str = format_labels(&metric.labels);
+
+        // Value lines
+        match &metric.value {
+            MetricValue::Counter(v) | MetricValue::Gauge(v) => {
+                output.push_str(&format!("{}{} {}\n", metric.name, labels_str, v));
+            }
+            MetricValue::Histogram {
+                sum,
+                count,
+                buckets,
+            } => {
+                for (le, c) in buckets {
+                    let mut bucket_labels = metric.labels.clone();
+                    bucket_labels.push(("le".to_string(), format!("{le}")));
+                    let bucket_labels_str = format_labels(&bucket_labels);
+                    output.push_str(&format!(
+                        "{}_bucket{} {}\n",
+                        metric.name, bucket_labels_str, c
+                    ));
+                }
+                // +Inf bucket
+                let mut inf_labels = metric.labels.clone();
+                inf_labels.push(("le".to_string(), "+Inf".to_string()));
+                let inf_labels_str = format_labels(&inf_labels);
+                output.push_str(&format!(
+                    "{}_bucket{} {}\n",
+                    metric.name, inf_labels_str, count
+                ));
+
+                output.push_str(&format!("{}_sum{} {}\n", metric.name, labels_str, sum));
+                output.push_str(&format!("{}_count{} {}\n", metric.name, labels_str, count));
+            }
+        }
+    }
+    output
+}
+
+fn format_labels(labels: &[(String, String)]) -> String {
+    if labels.is_empty() {
+        String::new()
+    } else {
+        let pairs: Vec<String> = labels.iter().map(|(k, v)| format!("{k}=\"{v}\"")).collect();
+        format!("{{{}}}", pairs.join(","))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_counter_metric() {
+        let metric = Metric::counter("http_requests_total", "Total HTTP requests", 1234.0);
+        assert_eq!(metric.name, "http_requests_total");
+        assert!(metric.labels.is_empty());
+        assert!(matches!(metric.value, MetricValue::Counter(v) if v == 1234.0));
+    }
+
+    #[test]
+    fn test_gauge_metric_with_labels() {
+        let metric = Metric::gauge("db_pool_active", "Active connections", 5.0)
+            .with_label("pool", "primary");
+        assert_eq!(metric.labels.len(), 1);
+        assert_eq!(
+            metric.labels[0],
+            ("pool".to_string(), "primary".to_string())
+        );
+    }
+
+    #[test]
+    fn test_prometheus_counter_format() {
+        let metrics = vec![Metric::counter(
+            "teaql_requests_total",
+            "Total requests",
+            42.0,
+        )];
+        let output = to_prometheus_exposition(&metrics);
+        assert!(output.contains("# HELP teaql_requests_total Total requests\n"));
+        assert!(output.contains("# TYPE teaql_requests_total counter\n"));
+        assert!(output.contains("teaql_requests_total 42\n"));
+    }
+
+    #[test]
+    fn test_prometheus_gauge_with_labels() {
+        let metrics = vec![
+            Metric::gauge("db_connections", "DB connections", 10.0).with_label("pool", "main"),
+        ];
+        let output = to_prometheus_exposition(&metrics);
+        assert!(output.contains("# TYPE db_connections gauge\n"));
+        assert!(output.contains("db_connections{pool=\"main\"} 10\n"));
+    }
+
+    #[test]
+    fn test_prometheus_histogram_format() {
+        let metrics = vec![Metric {
+            name: "query_duration_seconds".to_string(),
+            help: "Query duration".to_string(),
+            labels: Vec::new(),
+            value: MetricValue::Histogram {
+                sum: 12.5,
+                count: 155,
+                buckets: vec![(0.01, 100), (0.1, 150), (1.0, 155)],
+            },
+        }];
+        let output = to_prometheus_exposition(&metrics);
+        assert!(output.contains("# TYPE query_duration_seconds histogram\n"));
+        assert!(output.contains("query_duration_seconds_bucket{le=\"0.01\"} 100\n"));
+        assert!(output.contains("query_duration_seconds_bucket{le=\"0.1\"} 150\n"));
+        assert!(output.contains("query_duration_seconds_bucket{le=\"1\"} 155\n"));
+        assert!(output.contains("query_duration_seconds_bucket{le=\"+Inf\"} 155\n"));
+        assert!(output.contains("query_duration_seconds_sum 12.5\n"));
+        assert!(output.contains("query_duration_seconds_count 155\n"));
+    }
+
+    #[test]
+    fn test_prometheus_empty_metrics() {
+        let output = to_prometheus_exposition(&[]);
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn test_format_labels_empty() {
+        assert_eq!(format_labels(&[]), "");
+    }
+
+    #[test]
+    fn test_format_labels_multiple() {
+        let labels = vec![
+            ("method".to_string(), "GET".to_string()),
+            ("path".to_string(), "/api".to_string()),
+        ];
+        assert_eq!(format_labels(&labels), "{method=\"GET\",path=\"/api\"}");
+    }
+
+    struct MockCollector;
+
+    #[async_trait]
+    impl MetricsCollector for MockCollector {
+        async fn collect(&self) -> Vec<Metric> {
+            vec![Metric::counter("test_total", "Test counter", 1.0)]
+        }
+    }
+
+    #[tokio::test]
+    async fn test_metrics_collector_trait() {
+        let collector = MockCollector;
+        let metrics = collector.collect().await;
+        assert_eq!(metrics.len(), 1);
+        assert_eq!(metrics[0].name, "test_total");
+    }
+}

--- a/teaql-cloud-core/src/model.rs
+++ b/teaql-cloud-core/src/model.rs
@@ -1,0 +1,222 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// A service instance — the common model across all backends.
+///
+/// Represents a single running instance of a service, with its network
+/// address, health status, and optional metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServiceInstance {
+    /// Service name (e.g. "order-service")
+    pub service_name: String,
+    /// Unique instance ID (e.g. "order-service-192.168.1.10-8080")
+    pub instance_id: String,
+    /// IP address
+    pub ip: String,
+    /// Port number
+    pub port: u16,
+    /// Weight for load balancing (default 1.0)
+    pub weight: f64,
+    /// Whether this instance is healthy
+    pub healthy: bool,
+    /// Custom metadata (e.g. version, region, protocol)
+    pub metadata: HashMap<String, String>,
+}
+
+impl ServiceInstance {
+    /// Create a new service instance with auto-generated instance ID.
+    pub fn new(service_name: impl Into<String>, ip: impl Into<String>, port: u16) -> Self {
+        let service_name = service_name.into();
+        let ip = ip.into();
+        let instance_id = format!("{}-{}-{}", service_name, ip, port);
+        Self {
+            service_name,
+            instance_id,
+            ip,
+            port,
+            weight: 1.0,
+            healthy: true,
+            metadata: HashMap::new(),
+        }
+    }
+
+    /// Add a metadata key-value pair.
+    pub fn with_metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.metadata.insert(key.into(), value.into());
+        self
+    }
+
+    /// Set the load balancing weight.
+    pub fn with_weight(mut self, weight: f64) -> Self {
+        self.weight = weight;
+        self
+    }
+
+    /// Set the instance ID explicitly.
+    pub fn with_instance_id(mut self, id: impl Into<String>) -> Self {
+        self.instance_id = id.into();
+        self
+    }
+
+    /// Returns the `host:port` address string.
+    pub fn address(&self) -> String {
+        format!("{}:{}", self.ip, self.port)
+    }
+}
+
+impl Default for ServiceInstance {
+    fn default() -> Self {
+        Self {
+            service_name: String::new(),
+            instance_id: String::new(),
+            ip: "127.0.0.1".to_string(),
+            port: 8080,
+            weight: 1.0,
+            healthy: true,
+            metadata: HashMap::new(),
+        }
+    }
+}
+
+/// Service grouping configuration — maps to different concepts per backend.
+///
+/// - Nacos: namespace + group
+/// - Consul: datacenter
+/// - etcd: key prefix
+/// - K8s: namespace
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ServiceGroup {
+    pub namespace: Option<String>,
+    pub group: Option<String>,
+}
+
+impl ServiceGroup {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_namespace(mut self, ns: impl Into<String>) -> Self {
+        self.namespace = Some(ns.into());
+        self
+    }
+
+    pub fn with_group(mut self, group: impl Into<String>) -> Self {
+        self.group = Some(group.into());
+        self
+    }
+}
+
+/// Configuration identifier — locates a specific config entry.
+#[derive(Debug, Clone)]
+pub struct ConfigId {
+    /// Data ID (e.g. "order-service.yaml")
+    pub data_id: String,
+    /// Group name (e.g. "DEFAULT_GROUP")
+    pub group: String,
+    /// Optional namespace
+    pub namespace: Option<String>,
+}
+
+impl ConfigId {
+    pub fn new(data_id: impl Into<String>, group: impl Into<String>) -> Self {
+        Self {
+            data_id: data_id.into(),
+            group: group.into(),
+            namespace: None,
+        }
+    }
+
+    pub fn with_namespace(mut self, ns: impl Into<String>) -> Self {
+        self.namespace = Some(ns.into());
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_service_instance_new() {
+        let instance = ServiceInstance::new("order-service", "192.168.1.10", 8080);
+        assert_eq!(instance.service_name, "order-service");
+        assert_eq!(instance.instance_id, "order-service-192.168.1.10-8080");
+        assert_eq!(instance.ip, "192.168.1.10");
+        assert_eq!(instance.port, 8080);
+        assert_eq!(instance.weight, 1.0);
+        assert!(instance.healthy);
+        assert!(instance.metadata.is_empty());
+    }
+
+    #[test]
+    fn test_service_instance_builder() {
+        let instance = ServiceInstance::new("user-service", "10.0.0.1", 9090)
+            .with_weight(2.0)
+            .with_metadata("version", "1.0.0")
+            .with_metadata("region", "us-east-1")
+            .with_instance_id("custom-id");
+
+        assert_eq!(instance.weight, 2.0);
+        assert_eq!(instance.metadata.get("version").unwrap(), "1.0.0");
+        assert_eq!(instance.metadata.get("region").unwrap(), "us-east-1");
+        assert_eq!(instance.instance_id, "custom-id");
+    }
+
+    #[test]
+    fn test_service_instance_address() {
+        let instance = ServiceInstance::new("svc", "192.168.1.1", 3000);
+        assert_eq!(instance.address(), "192.168.1.1:3000");
+    }
+
+    #[test]
+    fn test_service_instance_default() {
+        let instance = ServiceInstance::default();
+        assert_eq!(instance.ip, "127.0.0.1");
+        assert_eq!(instance.port, 8080);
+        assert_eq!(instance.weight, 1.0);
+        assert!(instance.healthy);
+    }
+
+    #[test]
+    fn test_service_instance_serde_roundtrip() {
+        let instance =
+            ServiceInstance::new("test-svc", "10.0.0.1", 8080).with_metadata("env", "prod");
+        let json = serde_json::to_string(&instance).unwrap();
+        let deserialized: ServiceInstance = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.service_name, "test-svc");
+        assert_eq!(deserialized.metadata.get("env").unwrap(), "prod");
+    }
+
+    #[test]
+    fn test_service_group_builder() {
+        let group = ServiceGroup::new()
+            .with_namespace("production")
+            .with_group("DEFAULT_GROUP");
+        assert_eq!(group.namespace.unwrap(), "production");
+        assert_eq!(group.group.unwrap(), "DEFAULT_GROUP");
+    }
+
+    #[test]
+    fn test_service_group_default() {
+        let group = ServiceGroup::default();
+        assert!(group.namespace.is_none());
+        assert!(group.group.is_none());
+    }
+
+    #[test]
+    fn test_config_id() {
+        let config =
+            ConfigId::new("order-service.yaml", "DEFAULT_GROUP").with_namespace("production");
+        assert_eq!(config.data_id, "order-service.yaml");
+        assert_eq!(config.group, "DEFAULT_GROUP");
+        assert_eq!(config.namespace.unwrap(), "production");
+    }
+
+    #[test]
+    fn test_config_id_without_namespace() {
+        let config = ConfigId::new("app.toml", "MY_GROUP");
+        assert_eq!(config.data_id, "app.toml");
+        assert_eq!(config.group, "MY_GROUP");
+        assert!(config.namespace.is_none());
+    }
+}

--- a/teaql-cloud-core/src/registry.rs
+++ b/teaql-cloud-core/src/registry.rs
@@ -1,0 +1,91 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use crate::{CloudError, ServiceInstance};
+
+/// Service registration capability.
+///
+/// Manages the lifecycle: register → heartbeat (loop) → deregister.
+///
+/// Different backends implement heartbeat differently:
+/// - Nacos v2: gRPC persistent connection IS the heartbeat, `heartbeat()` is a no-op
+/// - etcd: Lease KeepAlive
+/// - Consul: TTL Check + PUT
+/// - K8s: No heartbeat needed (kubelet manages)
+#[async_trait]
+pub trait ServiceRegistry: Send + Sync {
+    /// Register a service instance with the registry.
+    async fn register(&self, instance: &ServiceInstance) -> Result<(), CloudError>;
+
+    /// Deregister a service instance from the registry.
+    async fn deregister(&self, instance: &ServiceInstance) -> Result<(), CloudError>;
+
+    /// Send a heartbeat / renew the lease for a service instance.
+    ///
+    /// For backends where the connection itself serves as the heartbeat
+    /// (e.g. Nacos v2 gRPC), this can be a no-op.
+    async fn heartbeat(&self, instance: &ServiceInstance) -> Result<(), CloudError>;
+
+    /// Recommended heartbeat interval.
+    ///
+    /// Returns `None` if the backend does not require explicit heartbeats
+    /// (e.g. Nacos v2 gRPC persistent connection).
+    fn heartbeat_interval(&self) -> Option<Duration> {
+        Some(Duration::from_secs(5))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockRegistry {
+        should_fail: bool,
+    }
+
+    #[async_trait]
+    impl ServiceRegistry for MockRegistry {
+        async fn register(&self, _instance: &ServiceInstance) -> Result<(), CloudError> {
+            if self.should_fail {
+                Err(CloudError::Registration("mock failure".to_string()))
+            } else {
+                Ok(())
+            }
+        }
+
+        async fn deregister(&self, _instance: &ServiceInstance) -> Result<(), CloudError> {
+            Ok(())
+        }
+
+        async fn heartbeat(&self, _instance: &ServiceInstance) -> Result<(), CloudError> {
+            Ok(())
+        }
+
+        fn heartbeat_interval(&self) -> Option<Duration> {
+            None // simulate gRPC-style no-heartbeat
+        }
+    }
+
+    #[tokio::test]
+    async fn test_mock_registry_register() {
+        let registry = MockRegistry { should_fail: false };
+        let instance = ServiceInstance::new("test-svc", "127.0.0.1", 8080);
+        assert!(registry.register(&instance).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_mock_registry_register_failure() {
+        let registry = MockRegistry { should_fail: true };
+        let instance = ServiceInstance::new("test-svc", "127.0.0.1", 8080);
+        let result = registry.register(&instance).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("mock failure"));
+    }
+
+    #[tokio::test]
+    async fn test_mock_registry_no_heartbeat_interval() {
+        let registry = MockRegistry { should_fail: false };
+        assert!(registry.heartbeat_interval().is_none());
+    }
+}


### PR DESCRIPTION
Closes #43

## Summary

New crate `teaql-cloud-core` providing all cloud integration abstractions:

- `CloudError` — unified error type
- `ServiceInstance`, `ServiceGroup`, `ConfigId` — domain models
- `ServiceRegistry` trait (register / deregister / heartbeat)
- `ServiceDiscovery` trait (get_instances / subscribe)
- `ConfigSource` trait (get_config / publish_config / watch)
- `HealthIndicator` trait + `HealthStatus` / `HealthDetail` / `HealthResponse`
- `MetricsCollector` trait + `to_prometheus_exposition()` Prometheus formatter
- `ServiceLifecycle` + `wait_for_shutdown_signal()` — graceful shutdown
- `SubscriptionHandle`, `WatchHandle` — cancellation handles

## Key design decisions

- **No dependency on `teaql-runtime` or `teaql-core`** — fully independent
- **Uses `#[async_trait]`** instead of RPITIT for object safety (`Arc<dyn ServiceRegistry>`)
- **`HealthStatus` serde** uses per-variant `#[serde(rename)]` for correct `OUT_OF_SERVICE` serialization

## Checklist

- [x] `cargo build -p teaql-cloud-core` succeeds
- [x] `cargo test -p teaql-cloud-core` — 45 tests passed
- [x] `cargo clippy -p teaql-cloud-core` — 0 warnings
- [x] `cargo fmt` applied
- [x] No dependency on teaql-runtime / teaql-core