### PR TITLE
feat: add teaql-cloud-actuator crate with health, info, and metrics endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2708,6 +2708,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "teaql-cloud-actuator"
+version = "4.1.1"
+dependencies = [
+ "async-trait",
+ "axum",
+ "serde",
+ "serde_json",
+ "teaql-cloud-core",
+ "tokio",
+ "tower",
+]
+
+[[package]]
 name = "teaql-cloud-core"
 version = "4.1.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "examples", "teaql-data-service", "teaql-web-integration-axum", "teaql-cache-integration-redis", "teaql-provider-meilisearch",
     "teaql-provider-linux",
     "teaql-cloud-core",
+    "teaql-cloud-actuator",
 ]
 resolver = "2"
 

--- a/teaql-cloud-actuator/Cargo.toml
+++ b/teaql-cloud-actuator/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "teaql-cloud-actuator"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Health, info, and metrics endpoints for TeaQL cloud integration (Spring Boot Actuator compatible)"
+repository.workspace = true
+readme = "README.md"
+
+[dependencies]
+teaql-cloud-core = { path = "../teaql-cloud-core", version = "4.1.1" }
+axum = { version = "0.7", features = ["macros"] }
+serde = { workspace = true }
+serde_json = "1"
+tokio = { workspace = true }
+
+[dev-dependencies]
+tower = "0.5"
+async-trait = { workspace = true }

--- a/teaql-cloud-actuator/src/health_handler.rs
+++ b/teaql-cloud-actuator/src/health_handler.rs
@@ -1,0 +1,219 @@
+use std::collections::HashMap;
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use teaql_cloud_core::{HealthDetail, HealthResponse, HealthStatus};
+
+use crate::ActuatorState;
+
+/// `GET /actuator/health`
+///
+/// Aggregated health check across all registered indicators.
+/// Response format is compatible with Spring Boot Actuator.
+///
+/// Returns HTTP 200 if UP, HTTP 503 if DOWN or OUT_OF_SERVICE.
+pub async fn health_handler(State(state): State<ActuatorState>) -> impl IntoResponse {
+    let (status, components) = check_all(&state).await;
+
+    let response = HealthResponse { status, components };
+
+    let http_status = match status {
+        HealthStatus::Up => StatusCode::OK,
+        _ => StatusCode::SERVICE_UNAVAILABLE,
+    };
+
+    (http_status, Json(response))
+}
+
+/// `GET /actuator/health/liveness`
+///
+/// Always returns UP if the process is running.
+/// Used by Kubernetes liveness probe — determines whether to **restart** the container.
+pub async fn liveness_handler() -> impl IntoResponse {
+    Json(serde_json::json!({ "status": "UP" }))
+}
+
+/// `GET /actuator/health/readiness`
+///
+/// Aggregates only indicators where `contributes_to_readiness() == true`.
+/// Used by Kubernetes readiness probe — determines whether to **route traffic**.
+///
+/// During shutdown, returns OUT_OF_SERVICE so the gateway stops routing.
+pub async fn readiness_handler(State(state): State<ActuatorState>) -> impl IntoResponse {
+    let mut components = HashMap::new();
+    let mut statuses = Vec::new();
+
+    for indicator in &state.indicators {
+        if indicator.contributes_to_readiness() {
+            let detail = indicator.check().await;
+            statuses.push(detail.status);
+            components.insert(indicator.name().to_string(), detail);
+        }
+    }
+
+    let status = HealthStatus::aggregate(&statuses);
+    let response = HealthResponse { status, components };
+
+    let http_status = match status {
+        HealthStatus::Up => StatusCode::OK,
+        _ => StatusCode::SERVICE_UNAVAILABLE,
+    };
+
+    (http_status, Json(response))
+}
+
+/// Check all health indicators and return aggregated status + component details.
+async fn check_all(state: &ActuatorState) -> (HealthStatus, HashMap<String, HealthDetail>) {
+    let mut components = HashMap::new();
+    let mut statuses = Vec::new();
+
+    for indicator in &state.indicators {
+        let detail = indicator.check().await;
+        statuses.push(detail.status);
+        components.insert(indicator.name().to_string(), detail);
+    }
+
+    let status = HealthStatus::aggregate(&statuses);
+    (status, components)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ServiceInfo;
+    use async_trait::async_trait;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::Request;
+    use axum::routing::get;
+    use std::sync::Arc;
+    use teaql_cloud_core::HealthIndicator;
+    use tower::ServiceExt;
+
+    struct UpIndicator;
+
+    #[async_trait]
+    impl HealthIndicator for UpIndicator {
+        fn name(&self) -> &str {
+            "db"
+        }
+        async fn check(&self) -> HealthDetail {
+            HealthDetail::up_with_details(serde_json::json!({ "database": "PostgreSQL" }))
+        }
+    }
+
+    struct DownIndicator;
+
+    #[async_trait]
+    impl HealthIndicator for DownIndicator {
+        fn name(&self) -> &str {
+            "cache"
+        }
+        async fn check(&self) -> HealthDetail {
+            HealthDetail::down("connection refused")
+        }
+    }
+
+    struct NonReadyIndicator;
+
+    #[async_trait]
+    impl HealthIndicator for NonReadyIndicator {
+        fn name(&self) -> &str {
+            "optional_cache"
+        }
+        async fn check(&self) -> HealthDetail {
+            HealthDetail::down("not configured")
+        }
+        fn contributes_to_readiness(&self) -> bool {
+            false
+        }
+    }
+
+    fn test_state(indicators: Vec<Arc<dyn HealthIndicator>>) -> ActuatorState {
+        ActuatorState {
+            indicators,
+            collectors: vec![],
+            info: ServiceInfo::default(),
+        }
+    }
+
+    fn test_app(state: ActuatorState) -> Router {
+        Router::new()
+            .route("/actuator/health", get(health_handler))
+            .route("/actuator/health/liveness", get(liveness_handler))
+            .route("/actuator/health/readiness", get(readiness_handler))
+            .with_state(state)
+    }
+
+    async fn get_json(app: Router, path: &str) -> (StatusCode, serde_json::Value) {
+        let response = app
+            .oneshot(Request::get(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        (status, json)
+    }
+
+    #[tokio::test]
+    async fn test_health_all_up() {
+        let state = test_state(vec![Arc::new(UpIndicator)]);
+        let app = test_app(state);
+        let (status, json) = get_json(app, "/actuator/health").await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(json["status"], "UP");
+        assert_eq!(json["components"]["db"]["status"], "UP");
+    }
+
+    #[tokio::test]
+    async fn test_health_with_down_component() {
+        let state = test_state(vec![Arc::new(UpIndicator), Arc::new(DownIndicator)]);
+        let app = test_app(state);
+        let (status, json) = get_json(app, "/actuator/health").await;
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(json["status"], "DOWN");
+        assert_eq!(json["components"]["db"]["status"], "UP");
+        assert_eq!(json["components"]["cache"]["status"], "DOWN");
+    }
+
+    #[tokio::test]
+    async fn test_liveness_always_up() {
+        let state = test_state(vec![Arc::new(DownIndicator)]);
+        let app = test_app(state);
+        let (status, json) = get_json(app, "/actuator/health/liveness").await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(json["status"], "UP");
+    }
+
+    #[tokio::test]
+    async fn test_readiness_excludes_non_contributing() {
+        let state = test_state(vec![Arc::new(UpIndicator), Arc::new(NonReadyIndicator)]);
+        let app = test_app(state);
+        let (status, json) = get_json(app, "/actuator/health/readiness").await;
+
+        // NonReadyIndicator is DOWN but contributes_to_readiness=false, so readiness=UP
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(json["status"], "UP");
+        // NonReadyIndicator should not appear in readiness components
+        assert!(json["components"].get("optional_cache").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_readiness_down_when_contributing_down() {
+        let state = test_state(vec![Arc::new(DownIndicator)]);
+        let app = test_app(state);
+        let (status, json) = get_json(app, "/actuator/health/readiness").await;
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(json["status"], "DOWN");
+    }
+}

--- a/teaql-cloud-actuator/src/info_handler.rs
+++ b/teaql-cloud-actuator/src/info_handler.rs
@@ -1,0 +1,91 @@
+use axum::Json;
+use axum::extract::State;
+
+use crate::ActuatorState;
+
+/// `GET /actuator/info`
+///
+/// Returns service build and runtime information.
+pub async fn info_handler(State(state): State<ActuatorState>) -> Json<serde_json::Value> {
+    Json(serde_json::to_value(&state.info).unwrap_or_default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ServiceInfo;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::routing::get;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_info_endpoint() {
+        let state = ActuatorState {
+            indicators: vec![],
+            collectors: vec![],
+            info: ServiceInfo {
+                name: "test-service".to_string(),
+                version: "1.2.3".to_string(),
+                git_commit: Some("deadbeef".to_string()),
+                build_time: Some("2026-07-20T12:00:00Z".to_string()),
+                rust_version: Some("1.87.0".to_string()),
+                profile: "release".to_string(),
+            },
+        };
+
+        let app = Router::new()
+            .route("/actuator/info", get(info_handler))
+            .with_state(state);
+
+        let response = app
+            .oneshot(Request::get("/actuator/info").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(json["name"], "test-service");
+        assert_eq!(json["version"], "1.2.3");
+        assert_eq!(json["git_commit"], "deadbeef");
+        assert_eq!(json["profile"], "release");
+    }
+
+    #[tokio::test]
+    async fn test_info_endpoint_minimal() {
+        let state = ActuatorState {
+            indicators: vec![],
+            collectors: vec![],
+            info: ServiceInfo {
+                name: "minimal".to_string(),
+                version: "0.1.0".to_string(),
+                ..ServiceInfo::default()
+            },
+        };
+
+        let app = Router::new()
+            .route("/actuator/info", get(info_handler))
+            .with_state(state);
+
+        let response = app
+            .oneshot(Request::get("/actuator/info").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(json["name"], "minimal");
+        // Optional fields should not appear
+        assert!(json.get("git_commit").is_none());
+        assert!(json.get("build_time").is_none());
+    }
+}

--- a/teaql-cloud-actuator/src/lib.rs
+++ b/teaql-cloud-actuator/src/lib.rs
@@ -1,0 +1,125 @@
+//! # teaql-cloud-actuator
+//!
+//! Health, info, and metrics endpoints for TeaQL cloud integration.
+//!
+//! Provides Spring Boot Actuator-compatible HTTP endpoints via Axum:
+//!
+//! - `GET /actuator/health` — aggregated health status
+//! - `GET /actuator/health/liveness` — process alive (K8s liveness probe)
+//! - `GET /actuator/health/readiness` — traffic ready (K8s readiness probe)
+//! - `GET /actuator/info` — service build/runtime info
+//! - `GET /actuator/metrics` — Prometheus exposition format
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use teaql_cloud_actuator::{actuator_routes, ActuatorState, ServiceInfo};
+//!
+//! let state = ActuatorState {
+//!     indicators: vec![Arc::new(my_health_indicator)],
+//!     collectors: vec![Arc::new(my_metrics_collector)],
+//!     info: ServiceInfo { name: "my-service".into(), version: "1.0".into(), ..Default::default() },
+//! };
+//!
+//! let app = Router::new()
+//!     .nest("/api", my_routes())
+//!     .merge(actuator_routes(state));
+//! ```
+
+mod health_handler;
+mod info_handler;
+mod metrics_handler;
+mod state;
+
+pub use state::{ActuatorState, ServiceInfo};
+
+use axum::Router;
+use axum::routing::get;
+
+/// Build the actuator router with all endpoints.
+///
+/// Endpoints:
+/// - `GET /actuator/health` — aggregated health (200 if UP, 503 otherwise)
+/// - `GET /actuator/health/liveness` — always 200 UP
+/// - `GET /actuator/health/readiness` — readiness-contributing indicators only
+/// - `GET /actuator/info` — service info JSON
+/// - `GET /actuator/metrics` — Prometheus exposition format (text/plain)
+pub fn actuator_routes(state: ActuatorState) -> Router {
+    Router::new()
+        .route("/actuator/health", get(health_handler::health_handler))
+        .route(
+            "/actuator/health/liveness",
+            get(health_handler::liveness_handler),
+        )
+        .route(
+            "/actuator/health/readiness",
+            get(health_handler::readiness_handler),
+        )
+        .route("/actuator/info", get(info_handler::info_handler))
+        .route("/actuator/metrics", get(metrics_handler::metrics_handler))
+        .with_state(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use std::sync::Arc;
+    use teaql_cloud_core::{HealthDetail, HealthIndicator, Metric, MetricsCollector};
+    use tower::ServiceExt;
+
+    struct TestIndicator;
+
+    #[async_trait::async_trait]
+    impl HealthIndicator for TestIndicator {
+        fn name(&self) -> &str {
+            "test"
+        }
+        async fn check(&self) -> HealthDetail {
+            HealthDetail::up()
+        }
+    }
+
+    struct TestCollector;
+
+    #[async_trait::async_trait]
+    impl MetricsCollector for TestCollector {
+        async fn collect(&self) -> Vec<Metric> {
+            vec![Metric::gauge("test_gauge", "A test gauge", 1.0)]
+        }
+    }
+
+    #[tokio::test]
+    async fn test_all_routes_accessible() {
+        let state = ActuatorState {
+            indicators: vec![Arc::new(TestIndicator)],
+            collectors: vec![Arc::new(TestCollector)],
+            info: ServiceInfo {
+                name: "integration-test".to_string(),
+                version: "0.1.0".to_string(),
+                ..ServiceInfo::default()
+            },
+        };
+
+        let app = actuator_routes(state);
+
+        let paths = [
+            "/actuator/health",
+            "/actuator/health/liveness",
+            "/actuator/health/readiness",
+            "/actuator/info",
+            "/actuator/metrics",
+        ];
+
+        for path in &paths {
+            let response = app
+                .clone()
+                .oneshot(Request::get(*path).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::OK, "Expected 200 for {path}");
+        }
+    }
+}

--- a/teaql-cloud-actuator/src/metrics_handler.rs
+++ b/teaql-cloud-actuator/src/metrics_handler.rs
@@ -1,0 +1,130 @@
+use axum::extract::State;
+use axum::http::header;
+use axum::response::IntoResponse;
+use teaql_cloud_core::to_prometheus_exposition;
+
+use crate::ActuatorState;
+
+/// `GET /actuator/metrics`
+///
+/// Returns metrics in Prometheus exposition format (text/plain).
+///
+/// Content-Type: `text/plain; version=0.0.4; charset=utf-8`
+pub async fn metrics_handler(State(state): State<ActuatorState>) -> impl IntoResponse {
+    let mut all_metrics = Vec::new();
+
+    for collector in &state.collectors {
+        let metrics = collector.collect().await;
+        all_metrics.extend(metrics);
+    }
+
+    let body = to_prometheus_exposition(&all_metrics);
+
+    (
+        [(
+            header::CONTENT_TYPE,
+            "text/plain; version=0.0.4; charset=utf-8",
+        )],
+        body,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ActuatorState, ServiceInfo};
+    use async_trait::async_trait;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::routing::get;
+    use std::sync::Arc;
+    use teaql_cloud_core::{Metric, MetricsCollector};
+    use tower::ServiceExt;
+
+    struct TestCollector;
+
+    #[async_trait]
+    impl MetricsCollector for TestCollector {
+        async fn collect(&self) -> Vec<Metric> {
+            vec![
+                Metric::counter("http_requests_total", "Total HTTP requests", 42.0)
+                    .with_label("method", "GET"),
+                Metric::gauge("db_pool_active", "Active DB connections", 5.0),
+            ]
+        }
+    }
+
+    #[tokio::test]
+    async fn test_metrics_endpoint() {
+        let state = ActuatorState {
+            indicators: vec![],
+            collectors: vec![Arc::new(TestCollector)],
+            info: ServiceInfo::default(),
+        };
+
+        let app = Router::new()
+            .route("/actuator/metrics", get(metrics_handler))
+            .with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::get("/actuator/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(content_type.contains("text/plain"));
+        assert!(content_type.contains("version=0.0.4"));
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(text.contains("# HELP http_requests_total Total HTTP requests"));
+        assert!(text.contains("# TYPE http_requests_total counter"));
+        assert!(text.contains("http_requests_total{method=\"GET\"} 42"));
+        assert!(text.contains("# TYPE db_pool_active gauge"));
+        assert!(text.contains("db_pool_active 5"));
+    }
+
+    #[tokio::test]
+    async fn test_metrics_endpoint_no_collectors() {
+        let state = ActuatorState {
+            indicators: vec![],
+            collectors: vec![],
+            info: ServiceInfo::default(),
+        };
+
+        let app = Router::new()
+            .route("/actuator/metrics", get(metrics_handler))
+            .with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::get("/actuator/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(body.is_empty());
+    }
+}

--- a/teaql-cloud-actuator/src/state.rs
+++ b/teaql-cloud-actuator/src/state.rs
@@ -1,0 +1,74 @@
+use serde::Serialize;
+use std::sync::Arc;
+use teaql_cloud_core::{HealthIndicator, MetricsCollector};
+
+/// Shared state for all actuator endpoints.
+#[derive(Clone)]
+pub struct ActuatorState {
+    pub indicators: Vec<Arc<dyn HealthIndicator>>,
+    pub collectors: Vec<Arc<dyn MetricsCollector>>,
+    pub info: ServiceInfo,
+}
+
+/// Service build and runtime information.
+///
+/// Displayed at `GET /actuator/info`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ServiceInfo {
+    pub name: String,
+    pub version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_commit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build_time: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rust_version: Option<String>,
+    pub profile: String,
+}
+
+impl Default for ServiceInfo {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            version: String::new(),
+            git_commit: None,
+            build_time: None,
+            rust_version: None,
+            profile: if cfg!(debug_assertions) {
+                "debug".to_string()
+            } else {
+                "release".to_string()
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_service_info_default() {
+        let info = ServiceInfo::default();
+        assert_eq!(info.profile, "debug"); // tests always run in debug
+        assert!(info.git_commit.is_none());
+        assert!(info.build_time.is_none());
+    }
+
+    #[test]
+    fn test_service_info_serialization() {
+        let info = ServiceInfo {
+            name: "order-service".to_string(),
+            version: "1.0.0".to_string(),
+            git_commit: Some("abc123".to_string()),
+            build_time: None,
+            rust_version: Some("1.87.0".to_string()),
+            profile: "release".to_string(),
+        };
+        let json = serde_json::to_value(&info).unwrap();
+        assert_eq!(json["name"], "order-service");
+        assert_eq!(json["git_commit"], "abc123");
+        // build_time is None, should be skipped
+        assert!(json.get("build_time").is_none());
+    }
+}


### PR DESCRIPTION
Closes #44

## Summary

New crate `teaql-cloud-actuator` providing Spring Boot Actuator-compatible HTTP endpoints via Axum:

- `GET /actuator/health` — aggregated health (200 UP, 503 DOWN/OUT_OF_SERVICE)
- `GET /actuator/health/liveness` — always 200 UP (K8s liveness probe)
- `GET /actuator/health/readiness` — readiness-contributing indicators only (K8s)
- `GET /actuator/info` — service build/runtime info JSON
- `GET /actuator/metrics` — Prometheus exposition format (text/plain; version=0.0.4)

## Modules

- `state.rs` — `ActuatorState`, `ServiceInfo`
- `health_handler.rs` — health/liveness/readiness handlers
- `info_handler.rs` — info handler
- `metrics_handler.rs` — Prometheus metrics handler
- `lib.rs` — `actuator_routes()` builder

## Checklist

- [x] All 5 endpoints respond correctly
- [x] 12 tests passed
- [x] `cargo clippy` — 0 warnings
- [x] `cargo fmt` applied