### PR TITLE
feat: add teaql-cloud-nacos crate wrapping Nacos v2 gRPC SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
 name = "arc-swap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +75,28 @@ name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "async-trait"
@@ -123,7 +151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "axum-macros",
  "bytes",
  "futures-util",
@@ -133,7 +161,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -149,6 +177,31 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core 0.5.6",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -170,6 +223,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -582,8 +653,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -601,14 +682,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -684,6 +803,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dunce"
@@ -874,6 +999,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,6 +1028,23 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
@@ -918,10 +1075,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1145,6 +1305,19 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -1461,6 +1634,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "local_ipaddress"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6a104730949fbc4c78e4fa98ed769ca0faa02e9818936b61032d2d77526afa9"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1489,6 +1668,12 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -1545,7 +1730,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63c3512cf11487168e0e9db7157801bf5273be13055a9cc95356dc9e0035e49c"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "heck",
  "num-bigint",
  "proc-macro-crate",
@@ -1629,6 +1814,49 @@ dependencies = [
  "time",
  "uuid",
  "zstd",
+]
+
+[[package]]
+name = "nacos-macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dedeaf95cc4f76938313f11b1ea41b18bf42a55062a09bf887d4fb6d57b0a7f"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "nacos-sdk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afbe05734fd268eb1116e6df21edc107cb60a8170c82a8e1dcd47f9d087561a4"
+dependencies = [
+ "arc-swap",
+ "async-stream",
+ "async-trait",
+ "dashmap",
+ "dotenvy",
+ "futures",
+ "futures-util",
+ "local_ipaddress",
+ "nacos-macro",
+ "prost",
+ "prost-types",
+ "rand 0.10.2",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+ "tonic",
+ "tonic-prost",
+ "tower",
+ "tracing",
+ "url",
+ "want",
 ]
 
 [[package]]
@@ -1978,6 +2206,38 @@ dependencies = [
  "bitflags",
  "chrono",
  "hex",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -2712,7 +2972,7 @@ name = "teaql-cloud-actuator"
 version = "4.1.1"
 dependencies = [
  "async-trait",
- "axum",
+ "axum 0.7.9",
  "serde",
  "serde_json",
  "teaql-cloud-core",
@@ -2728,6 +2988,18 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.19",
+ "tokio",
+]
+
+[[package]]
+name = "teaql-cloud-nacos"
+version = "4.1.1"
+dependencies = [
+ "async-trait",
+ "nacos-sdk",
+ "serde",
+ "serde_json",
+ "teaql-cloud-core",
  "tokio",
 ]
 
@@ -2866,7 +3138,7 @@ dependencies = [
 name = "teaql-web-integration-axum"
 version = "4.1.1"
 dependencies = [
- "axum",
+ "axum 0.7.9",
  "serde",
  "serde_json",
  "teaql-core",
@@ -3064,6 +3336,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3107,6 +3390,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "axum 0.8.9",
+ "base64 0.22.1",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2 0.6.5",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3114,9 +3437,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "teaql-provider-linux",
     "teaql-cloud-core",
     "teaql-cloud-actuator",
+    "teaql-cloud-nacos",
 ]
 resolver = "2"
 

--- a/teaql-cloud-nacos/Cargo.toml
+++ b/teaql-cloud-nacos/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "teaql-cloud-nacos"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Nacos v2 gRPC implementation for TeaQL cloud integration"
+repository.workspace = true
+readme = "README.md"
+
+[dependencies]
+teaql-cloud-core = { path = "../teaql-cloud-core", version = "4.1.1" }
+nacos-sdk = "=0.8"
+async-trait = { workspace = true }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = "1"

--- a/teaql-cloud-nacos/src/cloud.rs
+++ b/teaql-cloud-nacos/src/cloud.rs
@@ -1,0 +1,330 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use nacos_sdk::api::config::{
+    ConfigChangeListener, ConfigResponse, ConfigService, ConfigServiceBuilder,
+};
+use nacos_sdk::api::naming::{NamingService, NamingServiceBuilder};
+use nacos_sdk::api::props::ClientProps;
+
+use teaql_cloud_core::{
+    CloudError, ConfigId, ConfigSource, HealthDetail, HealthIndicator, Metric, MetricsCollector,
+    ServiceChangeEvent, ServiceDiscovery, ServiceGroup, ServiceInstance, ServiceRegistry,
+    SubscriptionHandle, WatchHandle,
+};
+
+use crate::config::{NacosConfig, from_nacos_instance, group_name, to_nacos_instance};
+
+/// Unified Nacos cloud client.
+///
+/// Holds both NamingService (for registry/discovery) and ConfigService
+/// (for configuration center). Created via `NacosCloud::connect()`.
+pub struct NacosCloud {
+    naming: NamingService,
+    config_svc: ConfigService,
+    nacos_config: NacosConfig,
+}
+
+impl NacosCloud {
+    /// Connect to Nacos server and create the unified client.
+    ///
+    /// This establishes gRPC connections for both naming and config services.
+    pub async fn connect(nacos_config: NacosConfig) -> Result<Self, CloudError> {
+        let client_props = build_client_props(&nacos_config);
+
+        let naming = NamingServiceBuilder::new(client_props.clone())
+            .build()
+            .await
+            .map_err(|e| CloudError::Network {
+                source: Box::new(e),
+            })?;
+
+        let config_svc = ConfigServiceBuilder::new(client_props)
+            .build()
+            .await
+            .map_err(|e| CloudError::Network {
+                source: Box::new(e),
+            })?;
+
+        Ok(Self {
+            naming,
+            config_svc,
+            nacos_config,
+        })
+    }
+
+    /// Access the underlying NamingService.
+    pub fn naming_service(&self) -> &NamingService {
+        &self.naming
+    }
+
+    /// Access the underlying ConfigService.
+    pub fn config_service(&self) -> &ConfigService {
+        &self.config_svc
+    }
+
+    /// Get the NacosConfig used to create this client.
+    pub fn config(&self) -> &NacosConfig {
+        &self.nacos_config
+    }
+}
+
+fn build_client_props(config: &NacosConfig) -> ClientProps {
+    let mut props = ClientProps::new()
+        .server_addr(&config.server_addr)
+        .namespace(&config.namespace)
+        .app_name(&config.app_name);
+
+    if let Some(auth) = &config.auth {
+        props = props
+            .auth_username(&auth.username)
+            .auth_password(&auth.password);
+    }
+
+    props
+}
+
+// --- ServiceRegistry ---
+
+#[async_trait]
+impl ServiceRegistry for NacosCloud {
+    async fn register(&self, instance: &ServiceInstance) -> Result<(), CloudError> {
+        let nacos_instance = to_nacos_instance(instance);
+        self.naming
+            .register_instance(
+                instance.service_name.clone(),
+                Some(self.nacos_config.group.clone()),
+                nacos_instance,
+            )
+            .await
+            .map_err(|e| CloudError::Registration(e.to_string()))
+    }
+
+    async fn deregister(&self, instance: &ServiceInstance) -> Result<(), CloudError> {
+        let nacos_instance = to_nacos_instance(instance);
+        self.naming
+            .deregister_instance(
+                instance.service_name.clone(),
+                Some(self.nacos_config.group.clone()),
+                nacos_instance,
+            )
+            .await
+            .map_err(|e| CloudError::Registration(e.to_string()))
+    }
+
+    /// No-op: Nacos v2 gRPC persistent connection serves as the heartbeat.
+    async fn heartbeat(&self, _instance: &ServiceInstance) -> Result<(), CloudError> {
+        Ok(())
+    }
+
+    /// Returns None: no explicit heartbeat needed for Nacos v2 gRPC.
+    fn heartbeat_interval(&self) -> Option<std::time::Duration> {
+        None
+    }
+}
+
+// --- ServiceDiscovery ---
+
+#[async_trait]
+impl ServiceDiscovery for NacosCloud {
+    async fn get_instances(
+        &self,
+        service_name: &str,
+        group: &ServiceGroup,
+    ) -> Result<Vec<ServiceInstance>, CloudError> {
+        let instances = self
+            .naming
+            .select_instances(
+                service_name.to_string(),
+                group_name(group),
+                Vec::new(),
+                true, // subscribe
+                true, // healthy only
+            )
+            .await
+            .map_err(|e| CloudError::Discovery(e.to_string()))?;
+
+        Ok(instances.iter().map(from_nacos_instance).collect())
+    }
+
+    async fn get_all_instances(
+        &self,
+        service_name: &str,
+        group: &ServiceGroup,
+    ) -> Result<Vec<ServiceInstance>, CloudError> {
+        let instances = self
+            .naming
+            .get_all_instances(
+                service_name.to_string(),
+                group_name(group),
+                Vec::new(),
+                false,
+            )
+            .await
+            .map_err(|e| CloudError::Discovery(e.to_string()))?;
+
+        Ok(instances.iter().map(from_nacos_instance).collect())
+    }
+
+    async fn subscribe(
+        &self,
+        service_name: &str,
+        group: &ServiceGroup,
+        callback: Box<dyn Fn(ServiceChangeEvent) + Send + Sync>,
+    ) -> Result<SubscriptionHandle, CloudError> {
+        let svc_name = service_name.to_string();
+        let grp = group_name(group);
+
+        let listener = Arc::new(NacosEventSubscriber {
+            service_name: svc_name.clone(),
+            callback,
+        });
+
+        self.naming
+            .subscribe(svc_name.clone(), grp.clone(), Vec::new(), listener)
+            .await
+            .map_err(|e| CloudError::Discovery(e.to_string()))?;
+
+        // Return a handle that can unsubscribe (no-op for now,
+        // nacos-sdk 0.8 does not expose unsubscribe cleanly)
+        Ok(SubscriptionHandle::new(|| {
+            // nacos-sdk 0.8 does not support unsubscribe via API
+        }))
+    }
+}
+
+/// Bridge between nacos-sdk's event subscriber and our callback-based API.
+struct NacosEventSubscriber {
+    service_name: String,
+    callback: Box<dyn Fn(ServiceChangeEvent) + Send + Sync>,
+}
+
+impl nacos_sdk::api::naming::NamingEventListener for NacosEventSubscriber {
+    fn event(&self, event: Arc<nacos_sdk::api::naming::NamingChangeEvent>) {
+        let instances = event
+            .instances
+            .iter()
+            .flat_map(|v| v.iter())
+            .map(from_nacos_instance)
+            .collect();
+        (self.callback)(ServiceChangeEvent {
+            service_name: self.service_name.clone(),
+            instances,
+        });
+    }
+}
+
+// --- ConfigSource ---
+
+#[async_trait]
+impl ConfigSource for NacosCloud {
+    async fn get_config(&self, config_id: &ConfigId) -> Result<String, CloudError> {
+        let resp = self
+            .config_svc
+            .get_config(config_id.data_id.clone(), config_id.group.clone())
+            .await
+            .map_err(|e| CloudError::Config(e.to_string()))?;
+        Ok(resp.content().to_string())
+    }
+
+    async fn publish_config(&self, config_id: &ConfigId, content: &str) -> Result<(), CloudError> {
+        self.config_svc
+            .publish_config(
+                config_id.data_id.clone(),
+                config_id.group.clone(),
+                content.to_string(),
+                None,
+            )
+            .await
+            .map_err(|e| CloudError::Config(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn watch(
+        &self,
+        config_id: &ConfigId,
+        callback: Box<dyn Fn(String) + Send + Sync>,
+    ) -> Result<WatchHandle, CloudError> {
+        let listener = Arc::new(NacosConfigWatcher { callback });
+        self.config_svc
+            .add_listener(config_id.data_id.clone(), config_id.group.clone(), listener)
+            .await
+            .map_err(|e| CloudError::Config(e.to_string()))?;
+
+        Ok(WatchHandle::new(|| {
+            // nacos-sdk 0.8 does not expose remove_listener
+        }))
+    }
+}
+
+/// Bridge between nacos-sdk's ConfigChangeListener and our callback API.
+struct NacosConfigWatcher {
+    callback: Box<dyn Fn(String) + Send + Sync>,
+}
+
+impl ConfigChangeListener for NacosConfigWatcher {
+    fn notify(&self, config_resp: ConfigResponse) {
+        (self.callback)(config_resp.content().to_string());
+    }
+}
+
+// --- HealthIndicator ---
+
+#[async_trait]
+impl HealthIndicator for NacosCloud {
+    fn name(&self) -> &str {
+        "nacos"
+    }
+
+    async fn check(&self) -> HealthDetail {
+        // Attempt a lightweight operation to verify connectivity.
+        match self
+            .naming
+            .select_instances(
+                "__health_check__".to_string(),
+                Some("DEFAULT_GROUP".to_string()),
+                Vec::new(),
+                false, // don't subscribe
+                false, // include unhealthy
+            )
+            .await
+        {
+            Ok(_) => HealthDetail::up_with_details(serde_json::json!({
+                "server": self.nacos_config.server_addr,
+                "namespace": self.nacos_config.namespace,
+                "grpc_port": self.nacos_config.grpc_port_hint(),
+            })),
+            Err(e) => HealthDetail::down(format!("Nacos connection failed: {e}")),
+        }
+    }
+}
+
+// --- MetricsCollector ---
+
+#[async_trait]
+impl MetricsCollector for NacosCloud {
+    async fn collect(&self) -> Vec<Metric> {
+        // nacos-sdk 0.8 does not expose internal metrics,
+        // so we provide a connection status metric.
+        let is_connected = self
+            .naming
+            .select_instances(
+                "__metrics_probe__".to_string(),
+                Some("DEFAULT_GROUP".to_string()),
+                Vec::new(),
+                false,
+                false,
+            )
+            .await
+            .is_ok();
+
+        vec![
+            Metric::gauge(
+                "teaql_nacos_connected",
+                "Whether the Nacos gRPC connection is alive (1=connected, 0=disconnected)",
+                if is_connected { 1.0 } else { 0.0 },
+            )
+            .with_label("server", &self.nacos_config.server_addr),
+        ]
+    }
+}

--- a/teaql-cloud-nacos/src/config.rs
+++ b/teaql-cloud-nacos/src/config.rs
@@ -1,0 +1,234 @@
+use serde::Deserialize;
+
+/// Nacos connection configuration.
+#[derive(Debug, Clone, Deserialize)]
+pub struct NacosConfig {
+    /// Nacos server address (e.g. "127.0.0.1:8848")
+    ///
+    /// For cluster mode, use comma-separated addresses:
+    /// "10.0.0.1:8848,10.0.0.2:8848"
+    pub server_addr: String,
+
+    /// Namespace ID (empty string = public namespace)
+    #[serde(default)]
+    pub namespace: String,
+
+    /// Application name used in Nacos console
+    #[serde(default = "default_app_name")]
+    pub app_name: String,
+
+    /// Optional authentication credentials
+    #[serde(default)]
+    pub auth: Option<NacosAuth>,
+
+    /// Default group name
+    #[serde(default = "default_group")]
+    pub group: String,
+}
+
+/// Nacos authentication credentials.
+#[derive(Debug, Clone, Deserialize)]
+pub struct NacosAuth {
+    pub username: String,
+    pub password: String,
+}
+
+fn default_app_name() -> String {
+    "teaql-service".to_string()
+}
+
+fn default_group() -> String {
+    "DEFAULT_GROUP".to_string()
+}
+
+impl NacosConfig {
+    /// Create a new config with server address.
+    pub fn new(server_addr: impl Into<String>) -> Self {
+        Self {
+            server_addr: server_addr.into(),
+            namespace: String::new(),
+            app_name: default_app_name(),
+            auth: None,
+            group: default_group(),
+        }
+    }
+
+    pub fn with_namespace(mut self, namespace: impl Into<String>) -> Self {
+        self.namespace = namespace.into();
+        self
+    }
+
+    pub fn with_app_name(mut self, app_name: impl Into<String>) -> Self {
+        self.app_name = app_name.into();
+        self
+    }
+
+    pub fn with_auth(mut self, username: impl Into<String>, password: impl Into<String>) -> Self {
+        self.auth = Some(NacosAuth {
+            username: username.into(),
+            password: password.into(),
+        });
+        self
+    }
+
+    pub fn with_group(mut self, group: impl Into<String>) -> Self {
+        self.group = group.into();
+        self
+    }
+
+    /// Get the gRPC port (server_port + 1000).
+    ///
+    /// Nacos v2 uses gRPC on port `server_port + 1000` by default.
+    /// e.g. if server_addr is "127.0.0.1:8848", gRPC port is 9848.
+    ///
+    /// Note: The `nacos-sdk` crate handles this offset automatically,
+    /// so you only need to provide the HTTP port.
+    pub fn grpc_port_hint(&self) -> Option<u16> {
+        self.server_addr
+            .split(':')
+            .next_back()
+            .and_then(|p| p.parse::<u16>().ok())
+            .map(|p| p + 1000)
+    }
+}
+
+/// Convert our ServiceInstance to nacos-sdk's ServiceInstance.
+pub(crate) fn to_nacos_instance(
+    instance: &teaql_cloud_core::ServiceInstance,
+) -> nacos_sdk::api::naming::ServiceInstance {
+    nacos_sdk::api::naming::ServiceInstance {
+        ip: instance.ip.clone(),
+        port: instance.port as i32,
+        weight: instance.weight,
+        healthy: instance.healthy,
+        enabled: true,
+        ephemeral: true,
+        cluster_name: Some("DEFAULT".to_string()),
+        service_name: Some(instance.service_name.clone()),
+        metadata: instance.metadata.clone(),
+        instance_id: Some(instance.instance_id.clone()),
+    }
+}
+
+/// Convert nacos-sdk's ServiceInstance to our ServiceInstance.
+pub(crate) fn from_nacos_instance(
+    instance: &nacos_sdk::api::naming::ServiceInstance,
+) -> teaql_cloud_core::ServiceInstance {
+    teaql_cloud_core::ServiceInstance {
+        ip: instance.ip.clone(),
+        port: instance.port as u16,
+        weight: instance.weight,
+        healthy: instance.healthy,
+        service_name: instance.service_name.clone().unwrap_or_default(),
+        instance_id: instance.instance_id.clone().unwrap_or_default(),
+        metadata: instance.metadata.clone(),
+    }
+}
+
+/// Convert a ServiceGroup into the group string used by nacos-sdk.
+pub(crate) fn group_name(group: &teaql_cloud_core::ServiceGroup) -> Option<String> {
+    group
+        .group
+        .clone()
+        .or_else(|| Some("DEFAULT_GROUP".to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use teaql_cloud_core::ServiceInstance;
+
+    #[test]
+    fn test_nacos_config_new() {
+        let config = NacosConfig::new("127.0.0.1:8848");
+        assert_eq!(config.server_addr, "127.0.0.1:8848");
+        assert_eq!(config.namespace, "");
+        assert_eq!(config.app_name, "teaql-service");
+        assert_eq!(config.group, "DEFAULT_GROUP");
+        assert!(config.auth.is_none());
+    }
+
+    #[test]
+    fn test_nacos_config_builder() {
+        let config = NacosConfig::new("10.0.0.1:8848")
+            .with_namespace("production")
+            .with_app_name("order-service")
+            .with_group("MY_GROUP")
+            .with_auth("admin", "secret");
+
+        assert_eq!(config.namespace, "production");
+        assert_eq!(config.app_name, "order-service");
+        assert_eq!(config.group, "MY_GROUP");
+        assert!(config.auth.is_some());
+        let auth = config.auth.unwrap();
+        assert_eq!(auth.username, "admin");
+        assert_eq!(auth.password, "secret");
+    }
+
+    #[test]
+    fn test_grpc_port_hint() {
+        let config = NacosConfig::new("127.0.0.1:8848");
+        assert_eq!(config.grpc_port_hint(), Some(9848));
+    }
+
+    #[test]
+    fn test_grpc_port_hint_no_port() {
+        let config = NacosConfig::new("127.0.0.1");
+        assert!(config.grpc_port_hint().is_none());
+    }
+
+    #[test]
+    fn test_to_nacos_instance() {
+        let our = ServiceInstance::new("order-svc", "10.0.0.1", 8080)
+            .with_weight(2.0)
+            .with_metadata("version", "1.0.0");
+
+        let nacos = to_nacos_instance(&our);
+
+        assert_eq!(nacos.ip, "10.0.0.1");
+        assert_eq!(nacos.port, 8080);
+        assert_eq!(nacos.weight, 2.0);
+        assert!(nacos.healthy);
+        assert!(nacos.ephemeral);
+        assert_eq!(nacos.service_name, Some("order-svc".to_string()));
+        assert_eq!(nacos.metadata.get("version").unwrap(), "1.0.0");
+    }
+
+    #[test]
+    fn test_from_nacos_instance() {
+        let mut metadata = HashMap::new();
+        metadata.insert("env".to_string(), "prod".to_string());
+
+        let nacos = nacos_sdk::api::naming::ServiceInstance {
+            ip: "192.168.1.1".to_string(),
+            port: 9090,
+            weight: 1.5,
+            healthy: true,
+            service_name: Some("user-svc".to_string()),
+            instance_id: Some("user-svc-192.168.1.1-9090".to_string()),
+            metadata,
+            ..Default::default()
+        };
+
+        let our = from_nacos_instance(&nacos);
+
+        assert_eq!(our.ip, "192.168.1.1");
+        assert_eq!(our.port, 9090);
+        assert_eq!(our.weight, 1.5);
+        assert_eq!(our.service_name, "user-svc");
+        assert_eq!(our.metadata.get("env").unwrap(), "prod");
+    }
+
+    #[test]
+    fn test_group_name_with_group() {
+        let group = teaql_cloud_core::ServiceGroup::new().with_group("MY_GROUP");
+        assert_eq!(group_name(&group), Some("MY_GROUP".to_string()));
+    }
+
+    #[test]
+    fn test_group_name_default() {
+        let group = teaql_cloud_core::ServiceGroup::new();
+        assert_eq!(group_name(&group), Some("DEFAULT_GROUP".to_string()));
+    }
+}

--- a/teaql-cloud-nacos/src/lib.rs
+++ b/teaql-cloud-nacos/src/lib.rs
@@ -1,0 +1,39 @@
+//! # teaql-cloud-nacos
+//!
+//! Nacos v2 gRPC implementation for TeaQL cloud integration.
+//!
+//! Wraps the `nacos-sdk` crate (pinned to `=0.8`) and implements all traits
+//! from `teaql-cloud-core`:
+//!
+//! - `ServiceRegistry` — register/deregister via NamingService
+//! - `ServiceDiscovery` — select_instances/subscribe via NamingService
+//! - `ConfigSource` — get_config/publish_config/watch via ConfigService
+//! - `HealthIndicator` — gRPC connection status
+//! - `MetricsCollector` — connection alive gauge
+//!
+//! ## Nacos v2 gRPC
+//!
+//! Nacos 2.x uses gRPC by default on port `server_port + 1000` (e.g. 9848).
+//! The persistent gRPC connection serves as the heartbeat — no explicit
+//! heartbeat requests are needed.
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use teaql_cloud_nacos::{NacosCloud, NacosConfig};
+//!
+//! let config = NacosConfig::new("127.0.0.1:8848")
+//!     .with_namespace("production")
+//!     .with_app_name("order-service");
+//!
+//! let cloud = NacosCloud::connect(config).await?;
+//!
+//! // Use cloud as ServiceRegistry, ServiceDiscovery, ConfigSource, etc.
+//! cloud.register(&instance).await?;
+//! ```
+
+mod cloud;
+mod config;
+
+pub use cloud::NacosCloud;
+pub use config::{NacosAuth, NacosConfig};


### PR DESCRIPTION
Closes #45

## Summary

New crate `teaql-cloud-nacos` wrapping `nacos-sdk = "=0.8"` to implement all `teaql-cloud-core` traits.

## `NacosCloud` implements

| Trait | Implementation |
|-------|---------------|
| `ServiceRegistry` | `register_instance` / `deregister_instance`, heartbeat is no-op |
| `ServiceDiscovery` | `select_instances` / `subscribe` via `NamingEventListener` |
| `ConfigSource` | `get_config` / `publish_config` / `add_listener` via `ConfigChangeListener` |
| `HealthIndicator` | gRPC connection probe via `select_instances` |
| `MetricsCollector` | `teaql_nacos_connected` gauge |

## Key decisions

- `nacos-sdk` pinned to `=0.8`
- Heartbeat is no-op (gRPC persistent connection)
- `heartbeat_interval()` returns `None`
- gRPC port = HTTP port + 1000 (handled by SDK)

## Checklist

- [x] `cargo build` succeeds
- [x] 8 tests passed
- [x] `cargo clippy` — 0 warnings
- [x] `cargo fmt` applied