### PR TITLE
docs: add cloud integration documentation and per-crate READMEs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,6 +19,28 @@ TeaQL abstracts database-specific implementations into separate provider crates:
 
 Each provider implements the execution traits required by the runtime, ensuring that the core logic remains database-agnostic.
 
+## Cloud Integration
+
+TeaQL provides cloud-native capabilities for embedding Rust services into Java microservice architectures:
+
+- `teaql-cloud-core` — Backend-agnostic trait definitions (ServiceRegistry, ServiceDiscovery, ConfigSource, HealthIndicator, MetricsCollector)
+- `teaql-cloud-actuator` — Spring Boot Actuator-compatible HTTP endpoints (health, info, metrics) via Axum
+- `teaql-cloud-nacos` — Nacos v2 gRPC implementation (wraps `nacos-sdk =0.8`)
+- `teaql-cloud-starter` — One-line bootstrap combining all cloud capabilities
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  teaql-cloud-starter                 │
+│  (CloudApp builder — one-line bootstrap)            │
+├──────────────────┬──────────────────┬───────────────┤
+│ teaql-cloud-     │ teaql-cloud-     │ teaql-cloud-  │
+│ actuator         │ nacos            │ core          │
+│ (Axum endpoints) │ (Nacos v2 gRPC)  │ (Traits)      │
+└──────────────────┴──────────────────┴───────────────┘
+```
+
+Design document: [docs/2026-07-20-cloud-integration-design.md](docs/2026-07-20-cloud-integration-design.md)
+
 ## Security Design Principles
 - **Input Validation**: All query parameters are strongly typed and sanitized by the underlying providers.
 - **Memory Safety**: Leveraging Rust's ownership model to prevent memory leaks and data races.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,36 @@ Progress tracking lives in [PROGRESS.md](./PROGRESS.md).
 
 Current published release: `4.0.0`.
 
+## Cloud Integration
+
+TeaQL provides cloud-native crates for embedding Rust services into Java (Spring Cloud) microservice architectures:
+
+```rust
+use teaql_cloud_starter::CloudApp;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    CloudApp::new()
+        .nacos("127.0.0.1:8848")
+        .namespace("production")
+        .service_name("order-service-rust")
+        .port(8080)
+        .routes(my_business_routes())
+        .start()
+        .await?;
+    Ok(())
+}
+```
+
+| Crate | Purpose |
+|-------|---------|
+| `teaql-cloud-core` | Backend-agnostic traits (ServiceRegistry, ServiceDiscovery, ConfigSource, HealthIndicator, MetricsCollector) |
+| `teaql-cloud-actuator` | Spring Boot Actuator-compatible endpoints (health, info, metrics) |
+| `teaql-cloud-nacos` | Nacos v2 gRPC implementation |
+| `teaql-cloud-starter` | One-line bootstrap — connects Nacos, registers service, starts HTTP, graceful shutdown |
+
+See [design document](docs/2026-07-20-cloud-integration-design.md) for details.
+
 ## Build & Install
 
 To build TeaQL from source:

--- a/teaql-cloud-actuator/README.md
+++ b/teaql-cloud-actuator/README.md
@@ -1,0 +1,52 @@
+# teaql-cloud-actuator
+
+Spring Boot Actuator-compatible health, info, and metrics endpoints for Axum.
+
+## Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/actuator/health` | GET | Aggregated health status (200 UP / 503 DOWN) |
+| `/actuator/health/liveness` | GET | Always UP — K8s liveness probe |
+| `/actuator/health/readiness` | GET | Readiness-contributing indicators — K8s readiness probe |
+| `/actuator/info` | GET | Service build/runtime info (JSON) |
+| `/actuator/metrics` | GET | Prometheus exposition format (text/plain) |
+
+## Usage
+
+```rust
+use teaql_cloud_actuator::{actuator_routes, ActuatorState, ServiceInfo};
+
+let state = ActuatorState {
+    indicators: vec![Arc::new(my_health_indicator)],
+    collectors: vec![Arc::new(my_metrics_collector)],
+    info: ServiceInfo {
+        name: "my-service".into(),
+        version: "1.0".into(),
+        ..Default::default()
+    },
+};
+
+let app = Router::new()
+    .nest("/api", my_routes())
+    .merge(actuator_routes(state));
+```
+
+## Spring Boot Compatibility
+
+The `/actuator/health` JSON output is compatible with Spring Boot Actuator format:
+
+```json
+{
+  "status": "UP",
+  "components": {
+    "db": { "status": "UP", "details": { "database": "PostgreSQL" } },
+    "nacos": { "status": "UP" }
+  }
+}
+```
+
+## Kubernetes Integration
+
+- **Liveness probe**: `GET /actuator/health/liveness` — always returns 200 if process is running
+- **Readiness probe**: `GET /actuator/health/readiness` — returns 503 during shutdown (OUT_OF_SERVICE)

--- a/teaql-cloud-core/README.md
+++ b/teaql-cloud-core/README.md
@@ -1,0 +1,36 @@
+# teaql-cloud-core
+
+Core trait definitions and shared models for TeaQL cloud integration.
+
+## Overview
+
+This crate provides the **abstraction layer** for embedding Rust services into Java microservice architectures. It defines backend-agnostic traits that can be implemented by any service discovery/configuration backend.
+
+**This crate has zero dependency on `teaql-runtime` or `teaql-core`** — it can be used in any Rust service.
+
+## Traits
+
+| Trait | Purpose |
+|-------|---------|
+| `ServiceRegistry` | Register / deregister / heartbeat |
+| `ServiceDiscovery` | Instance lookup and change subscription |
+| `ConfigSource` | Configuration retrieval, publishing, and watch |
+| `HealthIndicator` | Health check (Spring Boot Actuator compatible) |
+| `MetricsCollector` | Metrics with Prometheus exposition format |
+
+## Types
+
+- `ServiceInstance` — a running service instance with IP, port, weight, metadata
+- `ServiceGroup` — namespace + group (maps to Nacos/Consul/etcd/K8s concepts)
+- `ConfigId` — locates a specific config entry (data_id + group)
+- `HealthStatus` / `HealthDetail` / `HealthResponse` — health check results
+- `Metric` / `MetricValue` — Prometheus-compatible metrics
+- `ServiceLifecycle` — manages register → heartbeat → shutdown → deregister
+- `CloudError` — unified error type
+
+## Backend Implementations
+
+| Crate | Backend |
+|-------|---------|
+| `teaql-cloud-nacos` | Nacos v2 gRPC |
+| (future) | Consul, etcd, Kubernetes |

--- a/teaql-cloud-nacos/README.md
+++ b/teaql-cloud-nacos/README.md
@@ -1,0 +1,46 @@
+# teaql-cloud-nacos
+
+Nacos v2 gRPC implementation for TeaQL cloud integration.
+
+## Overview
+
+Wraps the [`nacos-sdk`](https://crates.io/crates/nacos-sdk) crate (pinned to `=0.8`) and implements all traits from `teaql-cloud-core`:
+
+| Trait | Implementation |
+|-------|---------------|
+| `ServiceRegistry` | `register_instance` / `deregister_instance` |
+| `ServiceDiscovery` | `select_instances` / `subscribe` |
+| `ConfigSource` | `get_config` / `publish_config` / `add_listener` |
+| `HealthIndicator` | gRPC connection probe |
+| `MetricsCollector` | `teaql_nacos_connected` gauge |
+
+## Nacos v2 gRPC
+
+- Nacos 2.x uses gRPC on port `server_port + 1000` (e.g. HTTP 8848 → gRPC 9848)
+- The persistent gRPC connection **IS** the heartbeat — no explicit beat needed
+- `heartbeat_interval()` returns `None`
+
+## Usage
+
+```rust
+use teaql_cloud_nacos::{NacosCloud, NacosConfig};
+
+let config = NacosConfig::new("127.0.0.1:8848")
+    .with_namespace("production")
+    .with_app_name("order-service");
+
+let cloud = NacosCloud::connect(config).await?;
+
+// Register
+cloud.register(&instance).await?;
+
+// Discover
+let instances = cloud.get_instances("user-service", &group).await?;
+
+// Config
+let config = cloud.get_config(&config_id).await?;
+```
+
+## Version Pinning
+
+`nacos-sdk` is pinned to `=0.8` to avoid breaking changes in the 0.x series.

--- a/teaql-cloud-starter/README.md
+++ b/teaql-cloud-starter/README.md
@@ -1,0 +1,47 @@
+# teaql-cloud-starter
+
+One-line cloud bootstrap for TeaQL Rust services — the Spring Boot Starter equivalent.
+
+## Overview
+
+Packages all cloud capabilities into a single `CloudApp` builder:
+
+- Nacos v2 gRPC connection
+- Service registration & discovery
+- Configuration center
+- Spring Boot Actuator-compatible endpoints (health/info/metrics)
+- Graceful shutdown (SIGINT/SIGTERM)
+
+## Usage
+
+```rust
+use teaql_cloud_starter::CloudApp;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    CloudApp::new()
+        .nacos("127.0.0.1:8848")
+        .namespace("production")
+        .service_name("order-service-rust")
+        .port(8080)
+        .routes(my_business_routes())
+        .start()
+        .await?;
+    // Graceful shutdown is handled automatically
+    Ok(())
+}
+```
+
+## What `start()` Does
+
+1. **Connect** to Nacos via gRPC
+2. **Register** service instance
+3. **Assemble** Axum Router (your routes + actuator routes)
+4. **Start** HTTP server
+5. **Wait** for SIGINT/SIGTERM
+6. **Shutdown**: readiness → OUT_OF_SERVICE → deregister → drain → exit
+
+## Auto-injected Components
+
+- `NacosCloud` as `HealthIndicator` (nacos connection health)
+- `NacosCloud` as `MetricsCollector` (connection alive gauge)


### PR DESCRIPTION
Closes #49

- README.md: Cloud Integration section with usage example
- ARCHITECTURE.md: Cloud crate architecture diagram
- teaql-cloud-core/README.md: Trait overview
- teaql-cloud-actuator/README.md: Endpoint docs + K8s integration
- teaql-cloud-nacos/README.md: Nacos v2 gRPC docs
- teaql-cloud-starter/README.md: CloudApp bootstrap docs