### PR TITLE
test: add cloud integration tests for lifecycle, actuator, and starter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3015,6 +3015,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "teaql-cloud-tests"
+version = "4.1.1"
+dependencies = [
+ "async-trait",
+ "axum 0.7.9",
+ "serde_json",
+ "teaql-cloud-actuator",
+ "teaql-cloud-core",
+ "teaql-cloud-nacos",
+ "teaql-cloud-starter",
+ "tokio",
+ "tower",
+]
+
+[[package]]
 name = "teaql-core"
 version = "4.1.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "teaql-cloud-actuator",
     "teaql-cloud-nacos",
     "teaql-cloud-starter",
+    "teaql-cloud-tests",
 ]
 resolver = "2"
 

--- a/teaql-cloud-tests/Cargo.toml
+++ b/teaql-cloud-tests/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "teaql-cloud-tests"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+teaql-cloud-core = { path = "../teaql-cloud-core" }
+teaql-cloud-actuator = { path = "../teaql-cloud-actuator" }
+teaql-cloud-nacos = { path = "../teaql-cloud-nacos" }
+teaql-cloud-starter = { path = "../teaql-cloud-starter" }
+axum = { version = "0.7" }
+tokio = { version = "1", features = ["full", "test-util"] }
+async-trait = { workspace = true }
+serde_json = "1"
+tower = "0.5"

--- a/teaql-cloud-tests/src/lib.rs
+++ b/teaql-cloud-tests/src/lib.rs
@@ -1,0 +1,1 @@
+// This crate is for integration tests only.

--- a/teaql-cloud-tests/tests/actuator_test.rs
+++ b/teaql-cloud-tests/tests/actuator_test.rs
@@ -1,0 +1,246 @@
+//! Integration tests: full actuator endpoint flow.
+//!
+//! Verifies all 5 endpoints work together with real health indicators
+//! and metrics collectors, end-to-end through Axum.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use teaql_cloud_actuator::{ActuatorState, ServiceInfo, actuator_routes};
+use teaql_cloud_core::{HealthDetail, HealthIndicator, Metric, MetricsCollector};
+use tower::ServiceExt;
+
+// --- Test indicators ---
+
+struct DatabaseIndicator {
+    healthy: bool,
+}
+
+#[async_trait]
+impl HealthIndicator for DatabaseIndicator {
+    fn name(&self) -> &str {
+        "db"
+    }
+    async fn check(&self) -> HealthDetail {
+        if self.healthy {
+            HealthDetail::up_with_details(serde_json::json!({
+                "database": "PostgreSQL",
+                "pool_size": 10
+            }))
+        } else {
+            HealthDetail::down("Connection pool exhausted")
+        }
+    }
+}
+
+struct NacosIndicator;
+
+#[async_trait]
+impl HealthIndicator for NacosIndicator {
+    fn name(&self) -> &str {
+        "nacos"
+    }
+    async fn check(&self) -> HealthDetail {
+        HealthDetail::up_with_details(serde_json::json!({
+            "server": "127.0.0.1:8848",
+            "namespace": "production"
+        }))
+    }
+}
+
+struct NonCriticalIndicator;
+
+#[async_trait]
+impl HealthIndicator for NonCriticalIndicator {
+    fn name(&self) -> &str {
+        "cache"
+    }
+    async fn check(&self) -> HealthDetail {
+        HealthDetail::down("Redis not configured")
+    }
+    fn contributes_to_readiness(&self) -> bool {
+        false // Optional component
+    }
+}
+
+// --- Test collectors ---
+
+struct AppMetrics;
+
+#[async_trait]
+impl MetricsCollector for AppMetrics {
+    async fn collect(&self) -> Vec<Metric> {
+        vec![
+            Metric::counter("http_requests_total", "Total HTTP requests", 1234.0)
+                .with_label("method", "GET")
+                .with_label("path", "/api/orders"),
+            Metric::gauge("db_pool_active", "Active DB connections", 5.0),
+            Metric::gauge("db_pool_idle", "Idle DB connections", 5.0),
+        ]
+    }
+}
+
+struct NacosMetrics;
+
+#[async_trait]
+impl MetricsCollector for NacosMetrics {
+    async fn collect(&self) -> Vec<Metric> {
+        vec![
+            Metric::gauge("teaql_nacos_connected", "Nacos connection status", 1.0)
+                .with_label("server", "127.0.0.1:8848"),
+        ]
+    }
+}
+
+// --- Test helpers ---
+
+fn build_state(db_healthy: bool, include_non_critical: bool) -> ActuatorState {
+    let mut indicators: Vec<Arc<dyn HealthIndicator>> = vec![
+        Arc::new(DatabaseIndicator {
+            healthy: db_healthy,
+        }),
+        Arc::new(NacosIndicator),
+    ];
+
+    if include_non_critical {
+        indicators.push(Arc::new(NonCriticalIndicator));
+    }
+
+    ActuatorState {
+        indicators,
+        collectors: vec![Arc::new(AppMetrics), Arc::new(NacosMetrics)],
+        info: ServiceInfo {
+            name: "order-service-rust".to_string(),
+            version: "4.1.1".to_string(),
+            git_commit: Some("abc123def".to_string()),
+            build_time: Some("2026-07-20T12:00:00Z".to_string()),
+            rust_version: Some("1.87.0".to_string()),
+            profile: "release".to_string(),
+        },
+    }
+}
+
+async fn get(app: axum::Router, path: &str) -> (StatusCode, String) {
+    let response = app
+        .oneshot(Request::get(path).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    (status, String::from_utf8(body.to_vec()).unwrap())
+}
+
+async fn get_json(app: axum::Router, path: &str) -> (StatusCode, serde_json::Value) {
+    let (status, body) = get(app, path).await;
+    let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+    (status, json)
+}
+
+// --- Tests ---
+
+#[tokio::test]
+async fn test_actuator_health_all_healthy() {
+    let app = actuator_routes(build_state(true, false));
+    let (status, json) = get_json(app, "/actuator/health").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["status"], "UP");
+    assert_eq!(json["components"]["db"]["status"], "UP");
+    assert_eq!(json["components"]["nacos"]["status"], "UP");
+    assert_eq!(
+        json["components"]["db"]["details"]["database"],
+        "PostgreSQL"
+    );
+}
+
+#[tokio::test]
+async fn test_actuator_health_db_down() {
+    let app = actuator_routes(build_state(false, false));
+    let (status, json) = get_json(app, "/actuator/health").await;
+
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(json["status"], "DOWN");
+    assert_eq!(json["components"]["db"]["status"], "DOWN");
+    // Nacos should still be UP
+    assert_eq!(json["components"]["nacos"]["status"], "UP");
+}
+
+#[tokio::test]
+async fn test_actuator_liveness_always_up() {
+    let app = actuator_routes(build_state(false, false));
+    let (status, json) = get_json(app, "/actuator/health/liveness").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["status"], "UP");
+}
+
+#[tokio::test]
+async fn test_actuator_readiness_ignores_non_critical() {
+    // DB and Nacos healthy, cache DOWN but contributes_to_readiness=false
+    let app = actuator_routes(build_state(true, true));
+    let (status, json) = get_json(app, "/actuator/health/readiness").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["status"], "UP");
+    // Cache should NOT appear in readiness
+    assert!(json["components"].get("cache").is_none());
+}
+
+#[tokio::test]
+async fn test_actuator_readiness_when_db_down() {
+    let app = actuator_routes(build_state(false, true));
+    let (status, json) = get_json(app, "/actuator/health/readiness").await;
+
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(json["status"], "DOWN");
+}
+
+#[tokio::test]
+async fn test_actuator_info_complete() {
+    let app = actuator_routes(build_state(true, false));
+    let (status, json) = get_json(app, "/actuator/info").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["name"], "order-service-rust");
+    assert_eq!(json["version"], "4.1.1");
+    assert_eq!(json["git_commit"], "abc123def");
+    assert_eq!(json["build_time"], "2026-07-20T12:00:00Z");
+    assert_eq!(json["rust_version"], "1.87.0");
+    assert_eq!(json["profile"], "release");
+}
+
+#[tokio::test]
+async fn test_actuator_metrics_prometheus_format() {
+    let app = actuator_routes(build_state(true, false));
+    let (status, body) = get(app, "/actuator/metrics").await;
+
+    assert_eq!(status, StatusCode::OK);
+
+    // Verify Prometheus exposition format
+    assert!(body.contains("# HELP http_requests_total Total HTTP requests"));
+    assert!(body.contains("# TYPE http_requests_total counter"));
+    assert!(body.contains(r#"http_requests_total{method="GET",path="/api/orders"} 1234"#));
+
+    assert!(body.contains("# TYPE db_pool_active gauge"));
+    assert!(body.contains("db_pool_active 5"));
+
+    assert!(body.contains("# TYPE teaql_nacos_connected gauge"));
+    assert!(body.contains(r#"teaql_nacos_connected{server="127.0.0.1:8848"} 1"#));
+}
+
+#[tokio::test]
+async fn test_actuator_metrics_aggregates_multiple_collectors() {
+    let app = actuator_routes(build_state(true, false));
+    let (_, body) = get(app, "/actuator/metrics").await;
+
+    // Should contain metrics from both AppMetrics and NacosMetrics
+    assert!(body.contains("http_requests_total"));
+    assert!(body.contains("db_pool_active"));
+    assert!(body.contains("db_pool_idle"));
+    assert!(body.contains("teaql_nacos_connected"));
+}

--- a/teaql-cloud-tests/tests/lifecycle_test.rs
+++ b/teaql-cloud-tests/tests/lifecycle_test.rs
@@ -1,0 +1,160 @@
+//! Integration tests: ServiceLifecycle with mock registry.
+//!
+//! Verifies the full lifecycle:
+//! 1. Start lifecycle with a mock registry
+//! 2. Verify registration was called
+//! 3. Trigger shutdown
+//! 4. Verify deregistration was called
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use teaql_cloud_core::{CloudError, ServiceInstance, ServiceLifecycle, ServiceRegistry};
+
+/// Mock registry that tracks register/deregister calls.
+struct MockRegistry {
+    registered: AtomicBool,
+    deregistered: AtomicBool,
+}
+
+impl MockRegistry {
+    fn new() -> Self {
+        Self {
+            registered: AtomicBool::new(false),
+            deregistered: AtomicBool::new(false),
+        }
+    }
+}
+
+#[async_trait]
+impl ServiceRegistry for MockRegistry {
+    async fn register(&self, _instance: &ServiceInstance) -> Result<(), CloudError> {
+        self.registered.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn deregister(&self, _instance: &ServiceInstance) -> Result<(), CloudError> {
+        self.deregistered.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn heartbeat(&self, _instance: &ServiceInstance) -> Result<(), CloudError> {
+        Ok(())
+    }
+
+    fn heartbeat_interval(&self) -> Option<Duration> {
+        None // No heartbeat loop
+    }
+}
+
+#[tokio::test]
+async fn test_lifecycle_register_and_shutdown() {
+    let registry = Arc::new(MockRegistry::new());
+    let instance = ServiceInstance::new("test-svc", "127.0.0.1", 8080);
+
+    // Start lifecycle — should call register
+    let lifecycle =
+        ServiceLifecycle::start(registry.clone() as Arc<dyn ServiceRegistry>, instance).await;
+
+    assert!(lifecycle.is_ok());
+    let lifecycle = lifecycle.unwrap();
+
+    // Verify registered
+    assert!(registry.registered.load(Ordering::SeqCst));
+    assert!(!registry.deregistered.load(Ordering::SeqCst));
+
+    // Trigger shutdown — should call deregister
+    let result = lifecycle.shutdown().await;
+    assert!(result.is_ok());
+    assert!(registry.deregistered.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn test_lifecycle_register_failure() {
+    struct FailRegistry;
+
+    #[async_trait]
+    impl ServiceRegistry for FailRegistry {
+        async fn register(&self, _instance: &ServiceInstance) -> Result<(), CloudError> {
+            Err(CloudError::Registration("connection refused".to_string()))
+        }
+
+        async fn deregister(&self, _instance: &ServiceInstance) -> Result<(), CloudError> {
+            Ok(())
+        }
+
+        async fn heartbeat(&self, _instance: &ServiceInstance) -> Result<(), CloudError> {
+            Ok(())
+        }
+
+        fn heartbeat_interval(&self) -> Option<Duration> {
+            None
+        }
+    }
+
+    let registry = Arc::new(FailRegistry);
+    let instance = ServiceInstance::new("test-svc", "127.0.0.1", 8080);
+
+    let result = ServiceLifecycle::start(registry as Arc<dyn ServiceRegistry>, instance).await;
+
+    assert!(result.is_err());
+    let err = result.err().unwrap();
+    match err {
+        CloudError::Registration(msg) => assert!(msg.contains("connection refused")),
+        other => panic!("Expected Registration error, got: {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_lifecycle_with_heartbeat() {
+    let heartbeat_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let hb = heartbeat_count.clone();
+
+    struct HeartbeatRegistry {
+        count: Arc<std::sync::atomic::AtomicU32>,
+        registered: AtomicBool,
+    }
+
+    #[async_trait]
+    impl ServiceRegistry for HeartbeatRegistry {
+        async fn register(&self, _instance: &ServiceInstance) -> Result<(), CloudError> {
+            self.registered.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn deregister(&self, _instance: &ServiceInstance) -> Result<(), CloudError> {
+            Ok(())
+        }
+
+        async fn heartbeat(&self, _instance: &ServiceInstance) -> Result<(), CloudError> {
+            self.count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        fn heartbeat_interval(&self) -> Option<Duration> {
+            Some(Duration::from_millis(50))
+        }
+    }
+
+    let registry = Arc::new(HeartbeatRegistry {
+        count: hb,
+        registered: AtomicBool::new(false),
+    });
+    let instance = ServiceInstance::new("test-svc", "127.0.0.1", 8080);
+
+    let lifecycle =
+        ServiceLifecycle::start(registry.clone() as Arc<dyn ServiceRegistry>, instance).await;
+    assert!(lifecycle.is_ok());
+    let lifecycle = lifecycle.unwrap();
+
+    // Wait a bit for heartbeats to fire
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Should have at least 1 heartbeat (probably 3-4 with 50ms interval over 200ms)
+    let count = heartbeat_count.load(Ordering::SeqCst);
+    assert!(count >= 1, "Expected at least 1 heartbeat, got {count}");
+
+    lifecycle.shutdown().await.unwrap();
+}

--- a/teaql-cloud-tests/tests/starter_test.rs
+++ b/teaql-cloud-tests/tests/starter_test.rs
@@ -1,0 +1,80 @@
+//! Integration tests: CloudApp builder configuration.
+//!
+//! These tests verify the builder pattern works correctly.
+//! Note: `CloudApp::start()` cannot be tested without a real Nacos server,
+//! so we only test the builder state.
+
+use teaql_cloud_starter::CloudApp;
+
+#[test]
+fn test_cloud_app_full_builder() {
+    let app = CloudApp::new()
+        .nacos("10.0.0.1:8848,10.0.0.2:8848")
+        .namespace("production")
+        .service_name("order-service-rust")
+        .ip("192.168.1.100")
+        .port(9090)
+        .version("4.1.1")
+        .group("CLOUD_GROUP")
+        .auth("admin", "secure-password");
+
+    // Verify builder correctly captures all fields
+    // (fields are private, but we can at least verify no panic)
+    drop(app);
+}
+
+#[test]
+fn test_cloud_app_minimal_builder() {
+    let app = CloudApp::new()
+        .nacos("127.0.0.1:8848")
+        .service_name("my-service");
+
+    drop(app);
+}
+
+#[test]
+fn test_cloud_app_with_custom_routes() {
+    use axum::Router;
+    use axum::routing::get;
+
+    let routes = Router::new().route("/hello", get(|| async { "Hello, World!" }));
+
+    let app = CloudApp::new()
+        .nacos("127.0.0.1:8848")
+        .service_name("hello-service")
+        .routes(routes);
+
+    drop(app);
+}
+
+#[test]
+fn test_cloud_app_with_custom_indicators() {
+    use async_trait::async_trait;
+    use std::sync::Arc;
+    use teaql_cloud_core::{HealthDetail, HealthIndicator};
+
+    struct CustomIndicator;
+
+    #[async_trait]
+    impl HealthIndicator for CustomIndicator {
+        fn name(&self) -> &str {
+            "custom"
+        }
+        async fn check(&self) -> HealthDetail {
+            HealthDetail::up()
+        }
+    }
+
+    let app = CloudApp::new()
+        .nacos("127.0.0.1:8848")
+        .service_name("custom-service")
+        .health_indicator(Arc::new(CustomIndicator));
+
+    drop(app);
+}
+
+#[test]
+fn test_cloud_app_default() {
+    let app = CloudApp::default();
+    drop(app);
+}


### PR DESCRIPTION
Closes #47

## Summary

New integration test crate `teaql-cloud-tests` (unpublished) with 16 tests across 3 test files:

### lifecycle_test.rs (3 tests)
- `test_lifecycle_register_and_shutdown` — verify register→shutdown→deregister flow
- `test_lifecycle_register_failure` — verify error propagation on registration failure
- `test_lifecycle_with_heartbeat` — verify heartbeat fires at configured interval

### actuator_test.rs (8 tests)
- Health: all-healthy (200), db-down (503)
- Liveness: always 200 even when DB down
- Readiness: filters non-contributing indicators, 503 when critical down
- Info: complete metadata JSON
- Metrics: Prometheus exposition format, multi-collector aggregation

### starter_test.rs (5 tests)
- CloudApp builder pattern: full, minimal, with routes, with indicators, default

All tests use mock implementations — no live Nacos server needed.

## Checklist
- [x] 16 tests passed
- [x] clippy clean