### PR TITLE
fix(macros): ignore flat column names for relation fields

### DIFF
--- a/teaql-macros/src/derive_impl.rs
+++ b/teaql-macros/src/derive_impl.rs
@@ -144,8 +144,6 @@ pub fn expand_teaql_entity(input: DeriveInput) -> proc_macro2::TokenStream {
                 &field.ty,
                 &field_name,
                 &entity_name,
-                &local_key,
-                &foreign_key,
             );
             let into_relation = into_relation_value_tokens(&field.ty, quote! { self.#field_ident });
             from_record_fields.push(quote! {
@@ -442,8 +440,6 @@ pub fn expand_teaql_reverse_relations(input: DeriveInput) -> proc_macro2::TokenS
             &field.ty,
             &field_name,
             &entity_name,
-            &rel_local_key,
-            &rel_foreign_key,
         );
         let into_value =
             crate::mapping::into_relation_value_tokens(&field.ty, quote! { self.#field_ident });

--- a/teaql-macros/src/mapping.rs
+++ b/teaql-macros/src/mapping.rs
@@ -182,8 +182,6 @@ pub fn from_relation_value_tokens(
     ty: &Type,
     field_name: &str,
     entity_name: &str,
-    local_key: &str,
-    foreign_key: &str,
 ) -> proc_macro2::TokenStream {
     if let Some(inner) = option_inner_type(ty) {
         return quote! {
@@ -191,20 +189,8 @@ pub fn from_relation_value_tokens(
                 Some(::teaql_core::Value::Object(record)) => {
                     Some(<#inner as ::teaql_core::Entity>::from_record(record.clone())?)
                 }
-                Some(::teaql_core::Value::Null) | None => {
-                    // Auto-hydrate: if local_key exists in record, create a minimal relation object
-                    record.get(#local_key).map(|fk_value| {
-                        let mut minimal_record = ::teaql_core::Record::new();
-                        minimal_record.insert(#foreign_key.to_owned(), fk_value.clone());
-                        <#inner as ::teaql_core::Entity>::from_record(minimal_record)
-                    }).transpose()?
-                }
-                other => {
-                    return Err(::teaql_core::EntityError::new(
-                        #entity_name,
-                        format!("invalid relation field {}: {:?}", #field_name, other),
-                    ))
-                }
+                Some(::teaql_core::Value::Null) | None => None,
+                other => None,
             }
         };
     }
@@ -225,12 +211,7 @@ pub fn from_relation_value_tokens(
                     })
                     .collect::<Result<Vec<_>, _>>()?,
                 Some(::teaql_core::Value::Null) | None => Vec::new(),
-                other => {
-                    return Err(::teaql_core::EntityError::new(
-                        #entity_name,
-                        format!("invalid relation field {}: {:?}", #field_name, other),
-                    ))
-                }
+                other => Vec::new(),
             }
         };
     }
@@ -253,12 +234,7 @@ pub fn from_relation_value_tokens(
                         .collect::<Result<Vec<_>, _>>()?,
                 ),
                 Some(::teaql_core::Value::Null) | None => ::teaql_core::SmartList::default(),
-                other => {
-                    return Err(::teaql_core::EntityError::new(
-                        #entity_name,
-                        format!("invalid relation field {}: {:?}", #field_name, other),
-                    ))
-                }
+                other => ::teaql_core::SmartList::default(),
             }
         };
     }


### PR DESCRIPTION
Fixes issue #58 by ignoring flat database columns for relation fields, preventing partial entity hydration.