### PR TITLE
ci: add CODECOV_TOKEN to fix rate limit issue

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,5 +20,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: cobertura.xml
           fail_ci_if_error: true


### PR DESCRIPTION
Fix Codecov rate limiting error (429) during coverage upload by supplying a repository token.