### PR TITLE
docs: fix outdated Q API example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,10 @@ let platforms = Q::platforms()
     .select_merchant_list_with(
         Q::merchants()
             .select_name()
-            .which_names_contain("TeaQL"),
+            .with_name_containing("TeaQL"),
     )
+    .comment("Load platforms with filtered merchant names")
+    .purpose("Displaying platform-merchant overview for dashboard")
     .execute_for_list(&ctx)
     .await?;
 ```


### PR DESCRIPTION
## Summary

Fix the generated Q API example in README.md to match the current API.

## Changes

1. **Method name**: `which_names_contain()` → `with_name_containing()` to match `teaql-code-gen` output
2. **Mandatory calls**: Add `.comment()` and `.purpose()` before `.execute_for_list()` per the Intent Auditing safeguard

## Related Issue

Fixes #71