### PR TITLE
Rust CI: document SQLite streaming guard and audit scope

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,5 @@
+[advisories]
+# rust_decimal declares rkyv 0.7 as an optional integration. It is present in
+# Cargo.lock metadata but is not enabled in TeaQL's resolved feature graph
+# (`cargo tree --all-features --target all -i rkyv` is empty).
+ignore = ["RUSTSEC-2026-0235"]

--- a/teaql-provider-sqlite/src/lib.rs
+++ b/teaql-provider-sqlite/src/lib.rs
@@ -316,6 +316,10 @@ impl SqlTransport for SqliteMutationExecutor {
 }
 
 impl teaql_sql::StreamingSqlTransport for SqliteMutationExecutor {
+    // A rusqlite statement and its rows borrow the guarded connection for the
+    // lifetime of the stream. This stream is intentionally local/non-Send, so
+    // retaining the synchronous guard across yields is required and safe.
+    #[allow(clippy::await_holding_lock)]
     fn stream_sql(
         &self,
         query: CompiledQuery,


### PR DESCRIPTION
Fixes the concrete CI failures from the governed streaming runtime merge. Local tests reproduce the corresponding CI checks.