### PR TITLE
fix(tfp): reject federated hard-limit overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3222,7 +3222,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "teaql-cache-integration-redis"
-version = "4.2.10"
+version = "4.2.11"
 dependencies = [
  "async-trait",
  "redis",
@@ -3234,7 +3234,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-cloud-actuator"
-version = "4.2.10"
+version = "4.2.11"
 dependencies = [
  "async-trait",
  "axum",
@@ -3247,7 +3247,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-cloud-consul"
-version = "4.2.10"
+version = "4.2.11"
 dependencies = [
  "async-trait",
  "reqwest 0.13.4",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-cloud-core"
-version = "4.2.10"
+version = "4.2.11"
 dependencies = [
  "async-trait",
  "serde",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-cloud-nacos"
-version = "4.2.10"
+version = "4.2.11"
 dependencies = [
  "async-trait",
  "nacos-sdk",
@@ -3281,7 +3281,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-cloud-starter"
-version = "4.2.10"
+version = "4.2.11"
 dependencies = [
  "axum",
  "teaql-cloud-actuator",
@@ -3293,7 +3293,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-cloud-tests"
-version = "4.2.10"
+version = "4.2.11"
 dependencies = [
  "async-trait",
  "axum",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-core"
-version = "4.2.10"
+version = "4.2.11"
 dependencies = [
  "chrono",
  "rust_decimal",
@@ -3319,7 +3319,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-data-service"
-version = "4.2.10"
+version = "4.2.11"
 dependencies = [
  "futures-core",
  "teaql-core",
@@ -3327,7 +3327,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-examples"
-version = "4.2.10"
+version = "4.2.11"
 dependencies = [
  "rusqlite",
  "teaql-core",
@@ -3340,7 +3340,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-macros"
-version = "4.2.10"
+version = "4.2.11"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-provider-linux"
-version = "4.2.10"
+version = "4.2.11"
 dependencies = [
  "chrono",
  "futures-util",
@@ -3362,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-provider-meilisearch"
-version = "4.2.10"
+version = "4.2.11"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -3375,7 +3375,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-provider-mysql"
-version = "4.2.10"
+version = "4.2.11"
 dependencies = [
  "async-stream",
  "chrono",
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-provider-postgres"
-version = "4.2.10"
+version = "4.2.11"
 dependencies = [
  "async-stream",
  "bytes",
@@ -3414,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-provider-sqlite"
-version = "4.2.10"
+version = "4.2.11"
 dependencies = [
  "async-stream",
  "chrono",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-runtime"
-version = "4.2.10"
+version = "4.2.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3450,7 +3450,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-sql"
-version = "4.2.10"
+version = "4.2.11"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-tfp-endpoint"
-version = "4.2.10"
+version = "4.2.11"
 dependencies = [
  "async-trait",
  "serde",
@@ -3474,7 +3474,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-web-integration-axum"
-version = "4.2.10"
+version = "4.2.11"
 dependencies = [
  "axum",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "4.2.10"
+version = "4.2.11"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["Philip"]
@@ -42,12 +42,12 @@ proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }
 
-teaql-core = { path = "teaql-core", version = "4.2.10" }
-teaql-macros = { path = "teaql-macros", version = "4.2.10" }
-teaql-runtime = { path = "teaql-runtime", version = "4.2.10" }
-teaql-sql = { path = "teaql-sql", version = "4.2.10" }
-teaql-provider-sqlite = { path = "teaql-provider-sqlite", version = "4.2.10" }
-teaql-provider-postgres = { path = "teaql-provider-postgres", version = "4.2.10" }
-teaql-provider-mysql = { path = "teaql-provider-mysql", version = "4.2.10" }
-teaql-data-service = { path = "teaql-data-service", version = "4.2.10" }
-teaql-provider-linux = { path = "teaql-provider-linux", version = "4.2.10" }
+teaql-core = { path = "teaql-core", version = "4.2.11" }
+teaql-macros = { path = "teaql-macros", version = "4.2.11" }
+teaql-runtime = { path = "teaql-runtime", version = "4.2.11" }
+teaql-sql = { path = "teaql-sql", version = "4.2.11" }
+teaql-provider-sqlite = { path = "teaql-provider-sqlite", version = "4.2.11" }
+teaql-provider-postgres = { path = "teaql-provider-postgres", version = "4.2.11" }
+teaql-provider-mysql = { path = "teaql-provider-mysql", version = "4.2.11" }
+teaql-data-service = { path = "teaql-data-service", version = "4.2.11" }
+teaql-provider-linux = { path = "teaql-provider-linux", version = "4.2.11" }

--- a/teaql-tfp-endpoint/src/lib.rs
+++ b/teaql-tfp-endpoint/src/lib.rs
@@ -231,12 +231,38 @@ fn reject_privileged_input(payload: &JsonValue) -> Result<(), String> {
         "requestPolicy",
         "purposePolicy",
         "trustedContext",
+        "hardLimit",
+        "hard_limit",
+        "hardLimitValue",
+        "hard_limit_value",
     ];
-    let object = payload.as_object().ok_or("TFP payload must be an object")?;
-    if let Some(field) = FORBIDDEN.iter().find(|field| object.contains_key(**field)) {
-        return Err(format!("Client cannot provide trusted field: {field}"));
+
+    fn reject_at(value: &JsonValue, path: &str, forbidden: &[&str]) -> Result<(), String> {
+        match value {
+            JsonValue::Object(object) => {
+                for (field, child) in object {
+                    if forbidden.contains(&field.as_str()) {
+                        return Err(format!(
+                            "Client cannot provide trusted or server-local field: {path}.{field}"
+                        ));
+                    }
+                    reject_at(child, &format!("{path}.{field}"), forbidden)?;
+                }
+            }
+            JsonValue::Array(values) => {
+                for (index, child) in values.iter().enumerate() {
+                    reject_at(child, &format!("{path}[{index}]"), forbidden)?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
     }
-    Ok(())
+
+    if !payload.is_object() {
+        return Err("TFP payload must be an object".into());
+    }
+    reject_at(payload, "$", FORBIDDEN)
 }
 
 fn validate_policy(trusted: &TrustedQueryContext, query: &TfpSelectQuery) -> Result<(), String> {
@@ -310,6 +336,30 @@ mod tests {
             reject_privileged_input(&json!({"entity":"CustomerOrder","_purpose":"requested"}))
                 .is_ok()
         );
+    }
+
+    #[test]
+    fn client_cannot_override_hard_limit_at_any_depth() {
+        for field in [
+            "hardLimit",
+            "hard_limit",
+            "hardLimitValue",
+            "hard_limit_value",
+        ] {
+            let error = reject_privileged_input(&json!({
+                "entity": "CustomerOrder",
+                (field): 20_000
+            }))
+            .unwrap_err();
+            assert!(error.contains(field));
+
+            let nested_error = reject_privileged_input(&json!({
+                "entity": "CustomerOrder",
+                "relations": [{"query": {(field): 20_000}}]
+            }))
+            .unwrap_err();
+            assert!(nested_error.contains(field));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reject hard-limit policy fields at every depth of an ordinary TFP payload
- cover camelCase and snake_case injection forms
- keep hard-limit configuration server-local
- prepare Rust workspace patch release `4.2.11`

## Verification

- `cargo test -p teaql-tfp-endpoint` (6/6)
- `cargo clippy -p teaql-tfp-endpoint --all-targets -- -D warnings`
- `cargo check -p teaql-tfp-endpoint`
- `cargo fmt --all`