### PR TITLE
fix(release): include TFP endpoint crate

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -7,6 +7,7 @@ CRATES=(
   "teaql-data-service"
   "teaql-sql"
   "teaql-runtime"
+  "teaql-tfp-endpoint"
   "teaql-provider-meilisearch"
   "teaql-provider-mysql"
   "teaql-provider-postgres"


### PR DESCRIPTION
## Summary

- add `teaql-tfp-endpoint` to the ordered crates.io publication list
- ensure federation security fixes are not omitted from Rust releases

## Verification

- `bash -n publish.sh`
- dependency order keeps core/data-service/runtime ahead of the endpoint