### PR TITLE
feat(query): optimize continuous ID pagination

### DIFF
--- a/teaql-core/src/lib.rs
+++ b/teaql-core/src/lib.rs
@@ -31,9 +31,9 @@ pub use mutation::{
 };
 pub use naming::default_table_name;
 pub use query::{
-    Aggregate, AggregateFunction, AggregationCacheOptions, NamedExpr, ObjectGroupBy, OrderBy,
-    PARTITION_RANK_PROPERTY, RawSqlProjection, Record, RelationAggregate, RelationLoad,
-    SelectQuery, Slice, SortDirection, StreamConfig, record_to_json_value,
+    Aggregate, AggregateFunction, AggregationCacheOptions, ContinuousPageFetchOptions, NamedExpr,
+    ObjectGroupBy, OrderBy, PARTITION_RANK_PROPERTY, RawSqlProjection, Record, RelationAggregate,
+    RelationLoad, SelectQuery, Slice, SortDirection, StreamConfig, record_to_json_value,
 };
 pub use safe_expression::{SafeExpression, TeaqlEmpty};
 pub use trace::TraceNode;

--- a/teaql-core/src/query.rs
+++ b/teaql-core/src/query.rs
@@ -37,6 +37,22 @@ mod hard_limit_tests {
                 .is_ok()
         );
     }
+
+    #[test]
+    fn continuous_page_fetch_is_explicit_and_validated() {
+        assert!(SelectQuery::new("Order").continuous_page_fetch.is_none());
+        let query =
+            SelectQuery::new("Order").optimize_for_continuous_page_fetch_with("recent-orders", 30);
+        let options = query.continuous_page_fetch.unwrap();
+        assert_eq!(options.namespace, "recent-orders");
+        assert_eq!(options.ttl_seconds, 30);
+    }
+
+    #[test]
+    #[should_panic(expected = "continuous page namespace must not be empty")]
+    fn continuous_page_fetch_rejects_empty_namespace() {
+        let _ = SelectQuery::new("Order").optimize_for_continuous_page_fetch_with(" ", 30);
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -310,6 +326,32 @@ pub struct StreamConfig {
     pub chunk_size: usize,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContinuousPageFetchOptions {
+    pub namespace: String,
+    pub ttl_seconds: u64,
+}
+
+impl ContinuousPageFetchOptions {
+    pub const DEFAULT_TTL_SECONDS: u64 = 600;
+
+    pub fn new(namespace: impl Into<String>, ttl_seconds: u64) -> Self {
+        let namespace = namespace.into();
+        assert!(
+            !namespace.trim().is_empty(),
+            "continuous page namespace must not be empty"
+        );
+        assert!(
+            ttl_seconds > 0,
+            "continuous page ttl_seconds must be positive"
+        );
+        Self {
+            namespace,
+            ttl_seconds,
+        }
+    }
+}
+
 impl Default for StreamConfig {
     fn default() -> Self {
         Self { chunk_size: 1000 }
@@ -343,6 +385,8 @@ pub struct SelectQuery {
     pub object_group_bys: Vec<ObjectGroupBy>,
     pub child_enhancements: Vec<SelectQuery>,
     pub stream_config: Option<StreamConfig>,
+    /// Explicit, process-local hint for transparent seek pagination of outer list queries.
+    pub continuous_page_fetch: Option<ContinuousPageFetchOptions>,
 }
 
 impl SelectQuery {
@@ -371,6 +415,7 @@ impl SelectQuery {
             object_group_bys: Vec::new(),
             child_enhancements: Vec::new(),
             stream_config: None,
+            continuous_page_fetch: None,
         }
     }
 
@@ -672,6 +717,23 @@ impl SelectQuery {
 
     pub fn page(self, offset: u64, limit: u64) -> Self {
         self.offset(offset).limit(limit)
+    }
+
+    pub fn optimize_for_continuous_page_fetch(mut self) -> Self {
+        self.continuous_page_fetch = Some(ContinuousPageFetchOptions::new(
+            "default",
+            ContinuousPageFetchOptions::DEFAULT_TTL_SECONDS,
+        ));
+        self
+    }
+
+    pub fn optimize_for_continuous_page_fetch_with(
+        mut self,
+        namespace: impl Into<String>,
+        ttl_seconds: u64,
+    ) -> Self {
+        self.continuous_page_fetch = Some(ContinuousPageFetchOptions::new(namespace, ttl_seconds));
+        self
     }
 
     /// Scope pagination to each distinct value of `field`.

--- a/teaql-runtime/src/context.rs
+++ b/teaql-runtime/src/context.rs
@@ -17,6 +17,87 @@ use crate::{
 };
 use crate::{DataServiceError, EntityRoot};
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct ContinuousPageCursor {
+    pub cursor_id: String,
+    pub query_key: String,
+    pub entity: String,
+    pub direction: teaql_core::SortDirection,
+    pub boundary: Value,
+    pub page_size: u64,
+    pub next_offset: u64,
+    pub expires_at: SystemTime,
+}
+
+#[async_trait::async_trait]
+pub trait ContinuousPageCursorStore: Send + Sync + 'static {
+    async fn get(
+        &self,
+        query_key: &str,
+        target_offset: u64,
+    ) -> Result<Option<ContinuousPageCursor>, String>;
+    async fn put(&self, cursor: ContinuousPageCursor) -> Result<(), String>;
+    async fn invalidate(&self, query_key: &str) -> Result<(), String>;
+}
+
+pub struct InMemoryContinuousPageCursorStore {
+    cursors: Mutex<HashMap<String, ContinuousPageCursor>>,
+    max_entries: usize,
+}
+
+impl Default for InMemoryContinuousPageCursorStore {
+    fn default() -> Self {
+        Self {
+            cursors: Mutex::new(HashMap::new()),
+            max_entries: 4096,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ContinuousPageCursorStore for InMemoryContinuousPageCursorStore {
+    async fn get(
+        &self,
+        query_key: &str,
+        target_offset: u64,
+    ) -> Result<Option<ContinuousPageCursor>, String> {
+        let key = format!("{query_key}:{target_offset}");
+        let mut cursors = self.cursors.lock().map_err(|e| e.to_string())?;
+        if cursors
+            .get(&key)
+            .is_some_and(|cursor| cursor.expires_at <= SystemTime::now())
+        {
+            cursors.remove(&key);
+        }
+        Ok(cursors.get(&key).cloned())
+    }
+
+    async fn put(&self, cursor: ContinuousPageCursor) -> Result<(), String> {
+        let key = format!("{}:{}", cursor.query_key, cursor.next_offset);
+        let mut cursors = self.cursors.lock().map_err(|e| e.to_string())?;
+        if cursors.len() >= self.max_entries {
+            if let Some(expired_or_oldest) = cursors
+                .iter()
+                .min_by_key(|(_, value)| value.expires_at)
+                .map(|(key, _)| key.clone())
+            {
+                cursors.remove(&expired_or_oldest);
+            }
+        }
+        cursors.insert(key, cursor);
+        Ok(())
+    }
+
+    async fn invalidate(&self, query_key: &str) -> Result<(), String> {
+        let prefix = format!("{query_key}:");
+        self.cursors
+            .lock()
+            .map_err(|e| e.to_string())?
+            .retain(|key, _| !key.starts_with(&prefix));
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SqlLogOperation {
     Select,
@@ -148,6 +229,8 @@ pub struct UserContext {
     user_identifier: Option<String>,
     timezone: Option<String>,
     trace_id: String,
+    continuous_page_cursor_store: std::sync::Arc<dyn ContinuousPageCursorStore>,
+    continuous_page_observation: Mutex<(String, Option<String>)>,
 }
 
 impl Default for UserContext {
@@ -189,6 +272,10 @@ impl Default for UserContext {
                     .unwrap_or_default()
                     .as_micros()
             ),
+            continuous_page_cursor_store: std::sync::Arc::new(
+                InMemoryContinuousPageCursorStore::default(),
+            ),
+            continuous_page_observation: Mutex::new(("DISABLED".to_owned(), None)),
         }
     }
 }
@@ -244,6 +331,41 @@ impl UserContext {
 
     pub fn set_user_identifier(&mut self, user_identifier: impl Into<String>) {
         self.user_identifier = Some(user_identifier.into());
+    }
+
+    pub fn set_continuous_page_cursor_store(
+        &mut self,
+        store: std::sync::Arc<dyn ContinuousPageCursorStore>,
+    ) {
+        self.continuous_page_cursor_store = store;
+    }
+
+    pub fn continuous_page_plan(&self) -> Option<String> {
+        self.continuous_page_observation
+            .lock()
+            .ok()
+            .map(|value| value.0.clone())
+    }
+
+    pub fn continuous_page_cursor_id(&self) -> Option<String> {
+        self.continuous_page_observation
+            .lock()
+            .ok()
+            .and_then(|value| value.1.clone())
+    }
+
+    pub(crate) fn observe_continuous_page(
+        &self,
+        plan: impl Into<String>,
+        cursor_id: Option<String>,
+    ) {
+        if let Ok(mut observation) = self.continuous_page_observation.lock() {
+            *observation = (plan.into(), cursor_id);
+        }
+    }
+
+    pub(crate) fn continuous_page_cursor_store(&self) -> &dyn ContinuousPageCursorStore {
+        self.continuous_page_cursor_store.as_ref()
     }
 
     pub fn with_user_identifier(mut self, user_identifier: impl Into<String>) -> Self {

--- a/teaql-runtime/src/data_service/resolved.rs
+++ b/teaql-runtime/src/data_service/resolved.rs
@@ -1,19 +1,32 @@
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
+use std::time::{Duration, SystemTime};
 
 use teaql_core::{
-    AggregationCacheOptions, DeleteCommand, Entity, InsertCommand, Record, RecoverCommand,
-    RelationAggregate, SelectQuery, SmartList, UpdateCommand, Value,
+    AggregationCacheOptions, DeleteCommand, Entity, Expr, InsertCommand, Record, RecoverCommand,
+    RelationAggregate, SelectQuery, SmartList, SortDirection, UpdateCommand, Value,
 };
 
 use crate::{
-    CheckObjectStatus, DataServiceError, EntityDataServiceBehavior, PurposedSelectQuery,
-    RawAuditEvent, RuntimeError, clear_record_status, mark_record_status,
+    CheckObjectStatus, ContinuousPageCursor, DataServiceError, EntityDataServiceBehavior,
+    PurposedSelectQuery, RawAuditEvent, RuntimeError, clear_record_status, mark_record_status,
 };
 
 use super::{
     AggregationCacheBackend, ContextDataService, EntityDataService, InMemoryAggregationCache,
     UserContextMetadata, helpers::*,
 };
+
+#[derive(Debug, Clone)]
+struct ContinuousPageExecution {
+    query_key: String,
+    direction: SortDirection,
+    page_size: u64,
+    original_offset: u64,
+    ttl_seconds: u64,
+    optimized: bool,
+    seek_cursor_id: Option<String>,
+}
 
 impl<'a, E> EntityDataService<'a, E>
 where
@@ -189,6 +202,199 @@ where
         self.fetch_prepared_all(&query).await
     }
 
+    async fn prepare_continuous_page(
+        &self,
+        query: SelectQuery,
+    ) -> (SelectQuery, Option<ContinuousPageExecution>) {
+        let Some(options) = query.continuous_page_fetch.as_ref() else {
+            self.data_service
+                .metadata
+                .context
+                .observe_continuous_page("DISABLED", None);
+            return (query, None);
+        };
+        let Some(slice) = query.slice.as_ref() else {
+            self.data_service
+                .metadata
+                .context
+                .observe_continuous_page("OFFSET_FALLBACK:INVALID_SLICE", None);
+            return (query, None);
+        };
+        let Some(page_size) = slice.limit else {
+            self.data_service
+                .metadata
+                .context
+                .observe_continuous_page("OFFSET_FALLBACK:INVALID_SLICE", None);
+            return (query, None);
+        };
+        if query.partition_by.is_some()
+            || !query.aggregates.is_empty()
+            || !query.group_by.is_empty()
+        {
+            self.data_service
+                .metadata
+                .context
+                .observe_continuous_page("OFFSET_FALLBACK:UNSUPPORTED_QUERY_SHAPE", None);
+            return (query, None);
+        }
+        if query.order_by.len() != 1
+            || query.order_by[0].field != "id"
+            || query.order_by[0].expr.is_some()
+        {
+            self.data_service
+                .metadata
+                .context
+                .observe_continuous_page("OFFSET_FALLBACK:ORDER_NOT_SEEKABLE_ID", None);
+            return (query, None);
+        }
+        let direction = query.order_by[0].direction;
+        let query_key = self.continuous_page_query_key(&query, &options.namespace);
+        let execution = ContinuousPageExecution {
+            query_key: query_key.clone(),
+            direction,
+            page_size,
+            original_offset: slice.offset,
+            ttl_seconds: options.ttl_seconds,
+            optimized: false,
+            seek_cursor_id: None,
+        };
+        if slice.offset == 0 {
+            self.data_service
+                .metadata
+                .context
+                .observe_continuous_page("OFFSET_FALLBACK:FIRST_PAGE", None);
+            return (query, Some(execution));
+        }
+        let cursor = match self
+            .data_service
+            .metadata
+            .context
+            .continuous_page_cursor_store()
+            .get(&query_key, slice.offset)
+            .await
+        {
+            Ok(Some(cursor)) => cursor,
+            Ok(None) => {
+                self.data_service
+                    .metadata
+                    .context
+                    .observe_continuous_page("OFFSET_FALLBACK:CACHE_MISS", None);
+                return (query, Some(execution));
+            }
+            Err(_) => {
+                self.data_service
+                    .metadata
+                    .context
+                    .observe_continuous_page("OFFSET_FALLBACK:STORE_UNAVAILABLE", None);
+                return (query, Some(execution));
+            }
+        };
+        if cursor.entity != query.entity
+            || cursor.direction != direction
+            || cursor.page_size != page_size
+            || cursor.next_offset != slice.offset
+            || cursor.expires_at <= SystemTime::now()
+        {
+            self.data_service
+                .metadata
+                .context
+                .observe_continuous_page("OFFSET_FALLBACK:CURSOR_INVALID", None);
+            return (query, Some(execution));
+        }
+        let mut optimized = query;
+        optimized.slice.as_mut().expect("validated slice").offset = 0;
+        optimized = optimized.and_filter(match direction {
+            SortDirection::Asc => Expr::gt("id", cursor.boundary.clone()),
+            SortDirection::Desc => Expr::lt("id", cursor.boundary.clone()),
+        });
+        let seek_cursor_id = cursor.cursor_id;
+        self.data_service
+            .metadata
+            .context
+            .observe_continuous_page("CURSOR_SEEK", Some(seek_cursor_id.clone()));
+        (
+            optimized,
+            Some(ContinuousPageExecution {
+                optimized: true,
+                seek_cursor_id: Some(seek_cursor_id),
+                ..execution
+            }),
+        )
+    }
+
+    async fn register_continuous_page(
+        &self,
+        execution: &Option<ContinuousPageExecution>,
+        rows: &[Record],
+    ) {
+        let Some(execution) = execution else { return };
+        if rows.len() as u64 != execution.page_size {
+            return;
+        }
+        let Some(boundary) = rows.last().and_then(|row| row.get("id")).cloned() else {
+            return;
+        };
+        let cursor_id = format!(
+            "cpg_{:x}",
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        );
+        let cursor = ContinuousPageCursor {
+            cursor_id,
+            query_key: execution.query_key.clone(),
+            entity: self.entity.clone(),
+            direction: execution.direction,
+            boundary,
+            page_size: execution.page_size,
+            next_offset: execution.original_offset + rows.len() as u64,
+            expires_at: SystemTime::now() + Duration::from_secs(execution.ttl_seconds),
+        };
+        if self
+            .data_service
+            .metadata
+            .context
+            .continuous_page_cursor_store()
+            .put(cursor)
+            .await
+            .is_err()
+        {
+            self.data_service
+                .metadata
+                .context
+                .observe_continuous_page("OFFSET_FALLBACK:STORE_UNAVAILABLE", None);
+        } else if execution.optimized {
+            self.data_service
+                .metadata
+                .context
+                .observe_continuous_page("CURSOR_SEEK", execution.seek_cursor_id.clone());
+        } else {
+            self.data_service
+                .metadata
+                .context
+                .observe_continuous_page("OFFSET_FALLBACK:FIRST_PAGE", None);
+        }
+    }
+
+    fn continuous_page_query_key(&self, query: &SelectQuery, namespace: &str) -> String {
+        let mut normalized = query.clone();
+        if let Some(slice) = normalized.slice.as_mut() {
+            slice.offset = 0;
+        }
+        normalized.comment = None;
+        normalized.trace_chain.clear();
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        namespace.hash(&mut hasher);
+        format!("{normalized:?}").hash(&mut hasher);
+        self.data_service
+            .metadata
+            .context
+            .user_identifier()
+            .hash(&mut hasher);
+        format!("teaql:continuous-page:v1:{:016x}", hasher.finish())
+    }
+
     /// Fetch root records from the provider cursor without materializing them.
     /// Relation and aggregate enhancement needs a separate batched protocol and
     /// is rejected here instead of silently returning incomplete entities.
@@ -254,21 +460,27 @@ where
         &self,
         query: &SelectQuery,
     ) -> Result<Vec<Record>, DataServiceError<E::Error>> {
-        let mut rows = self.fetch_prepared_query(query).await?;
+        let query = query
+            .clone()
+            .prepare_for_list()
+            .map_err(|message| DataServiceError::Runtime(RuntimeError::Graph(message)))?;
+        let (execution_query, continuous) = self.prepare_continuous_page(query).await;
+        let mut rows = self.fetch_prepared_query(&execution_query).await?;
         self.enhance_object_group_bys_internal(
             &mut rows,
-            &query.object_group_bys,
-            &query.trace_chain,
+            &execution_query.object_group_bys,
+            &execution_query.trace_chain,
         )
         .await?;
         self.enhance_child_queries_internal(
             &mut rows,
-            &query.child_enhancements,
-            &query.trace_chain,
+            &execution_query.child_enhancements,
+            &execution_query.trace_chain,
         )
         .await?;
-        self.enhance_query_relations_internal(&mut rows, query)
+        self.enhance_query_relations_internal(&mut rows, &execution_query)
             .await?;
+        self.register_continuous_page(&continuous, &rows).await;
         Ok(rows)
     }
 

--- a/teaql-runtime/src/lib.rs
+++ b/teaql-runtime/src/lib.rs
@@ -17,8 +17,9 @@ mod memory;
 mod registry;
 
 pub use context::{
-    DataStore, InMemoryDataStore, InfoLogEntry, LogPayload, SchemaProvider, SqlLogEntry,
-    SqlLogOperation, SqlLogOptions, UnifiedLogBuffer, UnifiedLogEntry, UserContext,
+    ContinuousPageCursor, ContinuousPageCursorStore, DataStore, InMemoryContinuousPageCursorStore,
+    InMemoryDataStore, InfoLogEntry, LogPayload, SchemaProvider, SqlLogEntry, SqlLogOperation,
+    SqlLogOptions, UnifiedLogBuffer, UnifiedLogEntry, UserContext,
 };
 pub use data_service::{
     AggregationCacheBackend, EntityDataService, GraphTransactionBoundary, InMemoryAggregationCache,
@@ -1822,6 +1823,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn continuous_page_fetch_uses_id_seek_for_the_next_page() {
+        let rows = (91_u64..=100)
+            .rev()
+            .map(|id| {
+                Record::from([
+                    (String::from("id"), Value::U64(id)),
+                    (String::from("version"), Value::I64(1)),
+                    (String::from("name"), Value::Text(format!("order-{id}"))),
+                ])
+            })
+            .collect();
+        let mut ctx = UserContext::new()
+            .with_user_identifier("tenant-1:user-1")
+            .with_metadata(InMemoryMetadataStore::new().with_entity(entity()))
+            .with_entity_registry(InMemoryEntityRegistry::new().with_entity("Order"));
+        ctx.insert_resource(PostgresDialect);
+        ctx.insert_resource(CapturingQueryExecutor {
+            rows,
+            queries: Mutex::new(Vec::new()),
+        });
+        let repo = ctx
+            .entity_data_service::<CapturingQueryExecutor>("Order")
+            .unwrap();
+
+        let first = SelectQuery::new("Order")
+            .order_desc("id")
+            .page(0, 10)
+            .optimize_for_continuous_page_fetch_with("recent-orders", 60);
+        repo.fetch_all_internal(&first).await.unwrap();
+        assert_eq!(
+            ctx.continuous_page_plan().as_deref(),
+            Some("OFFSET_FALLBACK:FIRST_PAGE")
+        );
+
+        let second = SelectQuery::new("Order")
+            .order_desc("id")
+            .page(10, 10)
+            .optimize_for_continuous_page_fetch_with("recent-orders", 60);
+        repo.fetch_all_internal(&second).await.unwrap();
+        assert_eq!(ctx.continuous_page_plan().as_deref(), Some("CURSOR_SEEK"));
+        assert!(ctx.continuous_page_cursor_id().is_some());
+
+        let captured = ctx
+            .get_resource::<CapturingQueryExecutor>()
+            .unwrap()
+            .queries
+            .lock()
+            .unwrap();
+        assert_eq!(
+            captured[1].slice.as_ref().map(|slice| slice.offset),
+            Some(0)
+        );
+        assert!(format!("{:?}", captured[1].filter).contains("Lt"));
+        assert!(format!("{:?}", captured[1].filter).contains("U64(91)"));
+    }
+
+    #[tokio::test]
     async fn aggregation_cache_is_namespaced_and_invalidated_after_write() {
         let executor = QueueExecutor {
             affected: 1,
@@ -2087,6 +2145,7 @@ mod tests {
             search_with_text: None,
             child_enhancements: Vec::new(),
             stream_config: None,
+            continuous_page_fetch: None,
         };
 
         let rows = data_service.fetch_all(&query).unwrap();

--- a/teaql-tfp-endpoint/src/models.rs
+++ b/teaql-tfp-endpoint/src/models.rs
@@ -403,6 +403,7 @@ mod tests {
         assert_eq!(core.aggregates[0].field, "id");
         assert_eq!(core.aggregates[0].alias, "record_count");
         assert_eq!(core.order_by[0].field, "order_number");
+        assert!(core.continuous_page_fetch.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- export continuous-page options and SelectQuery builder methods
- add process-local cursor storage and observable execution plans
- reject TFP propagation and keep the optimization outer-query/local only

## Fixes
Unblocks generated rust-lib-core calls to optimize_for_continuous_page_fetch that fail against teaql-core 4.2.11.

## Verification
The feature commit includes core validation and runtime pagination tests. CI must pass before merge.