### PR TITLE
chore: release TeaQL Rust 4.2.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3222,7 +3222,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "teaql-cache-integration-redis"
-version = "4.2.11"
+version = "4.2.12"
 dependencies = [
  "async-trait",
  "redis",
@@ -3234,7 +3234,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-cloud-actuator"
-version = "4.2.11"
+version = "4.2.12"
 dependencies = [
  "async-trait",
  "axum",
@@ -3247,7 +3247,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-cloud-consul"
-version = "4.2.11"
+version = "4.2.12"
 dependencies = [
  "async-trait",
  "reqwest 0.13.4",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-cloud-core"
-version = "4.2.11"
+version = "4.2.12"
 dependencies = [
  "async-trait",
  "serde",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-cloud-nacos"
-version = "4.2.11"
+version = "4.2.12"
 dependencies = [
  "async-trait",
  "nacos-sdk",
@@ -3281,7 +3281,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-cloud-starter"
-version = "4.2.11"
+version = "4.2.12"
 dependencies = [
  "axum",
  "teaql-cloud-actuator",
@@ -3293,7 +3293,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-cloud-tests"
-version = "4.2.11"
+version = "4.2.12"
 dependencies = [
  "async-trait",
  "axum",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-core"
-version = "4.2.11"
+version = "4.2.12"
 dependencies = [
  "chrono",
  "rust_decimal",
@@ -3319,7 +3319,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-data-service"
-version = "4.2.11"
+version = "4.2.12"
 dependencies = [
  "futures-core",
  "teaql-core",
@@ -3327,7 +3327,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-examples"
-version = "4.2.11"
+version = "4.2.12"
 dependencies = [
  "rusqlite",
  "teaql-core",
@@ -3340,7 +3340,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-macros"
-version = "4.2.11"
+version = "4.2.12"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-provider-linux"
-version = "4.2.11"
+version = "4.2.12"
 dependencies = [
  "chrono",
  "futures-util",
@@ -3362,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-provider-meilisearch"
-version = "4.2.11"
+version = "4.2.12"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -3375,7 +3375,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-provider-mysql"
-version = "4.2.11"
+version = "4.2.12"
 dependencies = [
  "async-stream",
  "chrono",
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-provider-postgres"
-version = "4.2.11"
+version = "4.2.12"
 dependencies = [
  "async-stream",
  "bytes",
@@ -3414,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-provider-sqlite"
-version = "4.2.11"
+version = "4.2.12"
 dependencies = [
  "async-stream",
  "chrono",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-runtime"
-version = "4.2.11"
+version = "4.2.12"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3450,7 +3450,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-sql"
-version = "4.2.11"
+version = "4.2.12"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-tfp-endpoint"
-version = "4.2.11"
+version = "4.2.12"
 dependencies = [
  "async-trait",
  "serde",
@@ -3474,7 +3474,7 @@ dependencies = [
 
 [[package]]
 name = "teaql-web-integration-axum"
-version = "4.2.11"
+version = "4.2.12"
 dependencies = [
  "axum",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "4.2.11"
+version = "4.2.12"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["Philip"]
@@ -42,12 +42,12 @@ proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }
 
-teaql-core = { path = "teaql-core", version = "4.2.11" }
-teaql-macros = { path = "teaql-macros", version = "4.2.11" }
-teaql-runtime = { path = "teaql-runtime", version = "4.2.11" }
-teaql-sql = { path = "teaql-sql", version = "4.2.11" }
-teaql-provider-sqlite = { path = "teaql-provider-sqlite", version = "4.2.11" }
-teaql-provider-postgres = { path = "teaql-provider-postgres", version = "4.2.11" }
-teaql-provider-mysql = { path = "teaql-provider-mysql", version = "4.2.11" }
-teaql-data-service = { path = "teaql-data-service", version = "4.2.11" }
-teaql-provider-linux = { path = "teaql-provider-linux", version = "4.2.11" }
+teaql-core = { path = "teaql-core", version = "4.2.12" }
+teaql-macros = { path = "teaql-macros", version = "4.2.12" }
+teaql-runtime = { path = "teaql-runtime", version = "4.2.12" }
+teaql-sql = { path = "teaql-sql", version = "4.2.12" }
+teaql-provider-sqlite = { path = "teaql-provider-sqlite", version = "4.2.12" }
+teaql-provider-postgres = { path = "teaql-provider-postgres", version = "4.2.12" }
+teaql-provider-mysql = { path = "teaql-provider-mysql", version = "4.2.12" }
+teaql-data-service = { path = "teaql-data-service", version = "4.2.12" }
+teaql-provider-linux = { path = "teaql-provider-linux", version = "4.2.12" }


### PR DESCRIPTION
## Summary
- bump the Rust workspace and internal dependencies to 4.2.12
- publish the SelectQuery continuous-page API merged in #94

## Verification
- cargo check --workspace: PASS
- cargo fmt --all -- --check: PASS
- cargo test --all-targets --all-features: PASS

This patch release fixes generated rust-lib-core compilation against the published runtime.