### PR TITLE
Add local dynamic-search warnings and retained Checker profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3535,6 +3535,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "rust_decimal",
+ "serde",
  "serde_json",
  "teaql-core",
  "teaql-data-service",

--- a/teaql-core/README.md
+++ b/teaql-core/README.md
@@ -29,7 +29,33 @@ let query = SelectQuery::new("Merchant")
 Use this crate when you need TeaQL metadata, query AST, entity traits, or
 in-memory value conversion without choosing a SQL dialect or runtime executor.
 
-## Workspace
+## Local dynamic-search schema drift
+
+`dynamic_search::normalize_dynamic_search` accepts a local UI-search JSON
+envelope (`filter`, `orderBy`) and application-owned `SearchModels`. Unknown
+fields and relation paths discard the complete clause and return value-free
+`DYNAMIC_SEARCH_UNKNOWN_FIELD` warnings. With no warning callback, warnings are
+logged as JSON to stderr. Malformed JSON, invalid operators/types and trusted
+context controls remain fatal; TFP validation is unchanged.
+
+`dynamic_search::merge_dynamic_search` compiles validated clauses through trusted
+native `Expr`/`OrderBy` bindings and clones the existing scoped query. Its filters
+are ANDed with the original predicate, ordering is appended, and hard limits,
+pagination and trace intent are retained. Bindings must preserve authorization
+inside related queries too. Validation or binding failure emits no partial
+warnings and never mutates the original query.
+
+Metadata types: `string`, `integer`, `number`, `boolean`, `date` (`yyyy-MM-dd`),
+`timestamp` (integer epoch milliseconds), and `decimal` (use strings for exact
+digits). Operators: `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$notIn`,
+and string `$contains`. Merge uses a 100-clause limit; normalization accepts an
+explicit trusted clause limit. Both bound paths to 16 segments and IN lists to
+1,000 values. Automatic generated bindings are not provided by this adapter.
+
+Tests: `teaql-core/tests/dynamic_search.rs` and
+`teaql-provider-sqlite/tests/dynamic_search.rs`.
+
+## Workspace links
 
 This crate is part of the `teaql-rs` workspace:
 

--- a/teaql-core/src/dynamic_search.rs
+++ b/teaql-core/src/dynamic_search.rs
@@ -1,0 +1,292 @@
+//! Local UI search input. This is not a permissive federation decoder.
+use crate::{Expr, OrderBy, SelectQuery};
+use serde::Serialize;
+use serde_json::{Map, Value};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Default)]
+pub struct SearchModel {
+    pub fields: BTreeMap<String, String>,
+    pub relations: BTreeMap<String, String>,
+}
+pub type SearchModels = BTreeMap<String, SearchModel>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DynamicSearchWarning {
+    pub code: &'static str,
+    pub entity: String,
+    pub clause: &'static str,
+    pub field_path: String,
+}
+#[derive(Debug, Clone, PartialEq)]
+pub struct DynamicSearchFilter {
+    pub field_path: String,
+    pub operator: String,
+    pub value: Value,
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DynamicSearchOrder {
+    pub field_path: String,
+    pub descending: bool,
+}
+#[derive(Debug, Clone)]
+pub struct NormalizedDynamicSearch {
+    pub filters: Vec<DynamicSearchFilter>,
+    pub orders: Vec<DynamicSearchOrder>,
+    pub warnings: Vec<DynamicSearchWarning>,
+}
+#[derive(Debug, Clone)]
+pub struct DynamicSearchResult {
+    pub query: SelectQuery,
+    pub warnings: Vec<DynamicSearchWarning>,
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DynamicSearchError(pub &'static str);
+impl std::fmt::Display for DynamicSearchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.0)
+    }
+}
+impl std::error::Error for DynamicSearchError {}
+type Result<T> = std::result::Result<T, DynamicSearchError>;
+
+/// Metadata and bounds must come from trusted application setup, never from source.
+/// Passing no warning sink uses structured stderr logging without submitted values.
+pub fn normalize_dynamic_search(
+    source: &str,
+    entity: &str,
+    models: &SearchModels,
+    max_clauses: usize,
+    warn: Option<&mut dyn FnMut(&DynamicSearchWarning)>,
+) -> Result<NormalizedDynamicSearch> {
+    if max_clauses == 0 || !models.contains_key(entity) {
+        return Err(DynamicSearchError("Invalid trusted search setup"));
+    }
+    let value: Value = serde_json::from_str(source)
+        .map_err(|_| DynamicSearchError("Dynamic search requires valid JSON"))?;
+    let root = value
+        .as_object()
+        .ok_or(DynamicSearchError("Expected search object"))?;
+    if root.keys().any(|k| k != "filter" && k != "orderBy") {
+        return Err(DynamicSearchError("Unsupported dynamic search control"));
+    }
+    let empty_filters = Map::new();
+    let empty_orders = Vec::new();
+    let filters = match root.get("filter") {
+        None => &empty_filters,
+        Some(value) => value
+            .as_object()
+            .ok_or(DynamicSearchError("Invalid search filter"))?,
+    };
+    let orders = match root.get("orderBy") {
+        None => &empty_orders,
+        Some(value) => value
+            .as_array()
+            .ok_or(DynamicSearchError("Invalid search ordering"))?,
+    };
+    if filters.len().saturating_add(orders.len()) > max_clauses {
+        return Err(DynamicSearchError("Dynamic search exceeds clause limit"));
+    }
+    let mut result = NormalizedDynamicSearch {
+        filters: vec![],
+        orders: vec![],
+        warnings: vec![],
+    };
+    for (path, predicate) in filters {
+        let (operator, value) = if let Some(parts) = predicate.as_object() {
+            if parts.len() != 1 {
+                return Err(DynamicSearchError("Malformed dynamic search operator"));
+            }
+            let (op, val) = parts.iter().next().unwrap();
+            if ![
+                "$eq",
+                "$ne",
+                "$gt",
+                "$gte",
+                "$lt",
+                "$lte",
+                "$in",
+                "$notIn",
+                "$contains",
+            ]
+            .contains(&op.as_str())
+            {
+                return Err(DynamicSearchError("Unsupported dynamic search operator"));
+            }
+            (op.as_str(), val)
+        } else {
+            ("$eq", predicate)
+        };
+        if matches!(operator, "$in" | "$notIn")
+            && !value.as_array().is_some_and(|values| values.len() <= 1000)
+        {
+            return Err(DynamicSearchError("Invalid or oversized search value list"));
+        }
+        let Some(kind) = field_type(path, entity, models)? else {
+            result.warnings.push(warning(entity, "FILTER", path));
+            continue;
+        };
+        if operator == "$contains" && kind != "string" {
+            return Err(DynamicSearchError(
+                "String operator requires a string field",
+            ));
+        }
+        if let Some(items) = value.as_array() {
+            if !matches!(operator, "$in" | "$notIn") {
+                return Err(DynamicSearchError("Unexpected search value list"));
+            }
+            for item in items {
+                validate_scalar(item, kind)?;
+            }
+        } else {
+            validate_scalar(value, kind)?;
+        }
+        result.filters.push(DynamicSearchFilter {
+            field_path: path.clone(),
+            operator: operator.into(),
+            value: value.clone(),
+        });
+    }
+    for value in orders {
+        let order = value
+            .as_object()
+            .ok_or(DynamicSearchError("Invalid search ordering"))?;
+        let path = order
+            .get("field")
+            .and_then(Value::as_str)
+            .ok_or(DynamicSearchError("Invalid ordering field"))?;
+        let direction = order
+            .get("direction")
+            .and_then(Value::as_str)
+            .ok_or(DynamicSearchError("Invalid ordering direction"))?;
+        if order.len() != 2 || !matches!(direction, "asc" | "desc") {
+            return Err(DynamicSearchError("Invalid dynamic search ordering"));
+        }
+        if field_type(path, entity, models)?.is_none() {
+            result.warnings.push(warning(entity, "ORDER_BY", path));
+        } else {
+            result.orders.push(DynamicSearchOrder {
+                field_path: path.into(),
+                descending: direction == "desc",
+            });
+        }
+    }
+    emit(&result.warnings, warn);
+    Ok(result)
+}
+
+/// Compile through trusted native bindings and retain the existing scoped query.
+/// Bindings own canonical names and authorization inside related queries.
+pub fn merge_dynamic_search(
+    base: &SelectQuery,
+    source: &str,
+    models: &SearchModels,
+    mut filter_binding: impl FnMut(&DynamicSearchFilter) -> Result<Expr>,
+    mut order_binding: impl FnMut(&DynamicSearchOrder) -> Result<OrderBy>,
+    warn: Option<&mut dyn FnMut(&DynamicSearchWarning)>,
+) -> Result<DynamicSearchResult> {
+    let search = normalize_dynamic_search(source, &base.entity, models, 100, Some(&mut |_| {}))?;
+    let filters = search
+        .filters
+        .iter()
+        .map(&mut filter_binding)
+        .collect::<Result<Vec<_>>>()?;
+    let orders = search
+        .orders
+        .iter()
+        .map(&mut order_binding)
+        .collect::<Result<Vec<_>>>()?;
+    let mut query = base.clone();
+    for filter in filters {
+        query = query.and_filter(filter);
+    }
+    query.order_by.extend(orders);
+    emit(&search.warnings, warn);
+    Ok(DynamicSearchResult {
+        query,
+        warnings: search.warnings,
+    })
+}
+
+fn field_type<'a>(path: &str, entity: &str, models: &'a SearchModels) -> Result<Option<&'a str>> {
+    let parts: Vec<_> = path.split('.').collect();
+    if parts.len() > 16
+        || parts.iter().any(|p| {
+            p.is_empty()
+                || p.starts_with('$')
+                || matches!(*p, "__proto__" | "prototype" | "constructor")
+        })
+    {
+        return Err(DynamicSearchError("Invalid search field path"));
+    }
+    let mut model = &models[entity];
+    for part in &parts[..parts.len() - 1] {
+        let Some(target) = model.relations.get(*part) else {
+            return Ok(None);
+        };
+        model = models.get(target).ok_or(DynamicSearchError(
+            "Invalid trusted search relation metadata",
+        ))?;
+    }
+    Ok(model.fields.get(*parts.last().unwrap()).map(String::as_str))
+}
+
+fn validate_scalar(value: &Value, kind: &str) -> Result<()> {
+    if value.is_null() {
+        return Ok(());
+    }
+    let number = value.as_f64().filter(|n| n.is_finite());
+    let valid = match kind {
+        "integer" | "timestamp" => {
+            number.is_some_and(|n| n.abs() <= 9_007_199_254_740_991.0 && n.fract() == 0.0)
+        }
+        "number" => number.is_some(),
+        "string" => value.is_string(),
+        "boolean" => value.is_boolean(),
+        "decimal" => number.is_some() || value.as_str().is_some_and(decimal_text),
+        "date" => value.as_str().is_some_and(|s| {
+            s.len() == 10
+                && chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d").is_ok_and(|date| {
+                    date.format("%Y-%m-%d").to_string() == s && !s.starts_with("0000")
+                })
+        }),
+        _ => false,
+    };
+    if valid {
+        Ok(())
+    } else {
+        Err(DynamicSearchError("Invalid value for known search field"))
+    }
+}
+fn decimal_text(text: &str) -> bool {
+    let text = text
+        .strip_prefix('+')
+        .or_else(|| text.strip_prefix('-'))
+        .unwrap_or(text);
+    let parts: Vec<_> = text.split('.').collect();
+    parts.len() <= 2
+        && parts
+            .iter()
+            .all(|part| !part.is_empty() && part.bytes().all(|c| c.is_ascii_digit()))
+}
+fn warning(entity: &str, clause: &'static str, path: &str) -> DynamicSearchWarning {
+    DynamicSearchWarning {
+        code: "DYNAMIC_SEARCH_UNKNOWN_FIELD",
+        entity: entity.into(),
+        clause,
+        field_path: path.into(),
+    }
+}
+fn emit(
+    warnings: &[DynamicSearchWarning],
+    mut warn: Option<&mut dyn FnMut(&DynamicSearchWarning)>,
+) {
+    for warning in warnings {
+        if let Some(ref mut sink) = warn {
+            sink(warning);
+        } else if let Ok(json) = serde_json::to_string(warning) {
+            eprintln!("{json}");
+        }
+    }
+}

--- a/teaql-core/src/lib.rs
+++ b/teaql-core/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate self as teaql_core;
 
+pub mod dynamic_search;
 mod entity;
 mod entity_graph;
 mod expr;

--- a/teaql-core/tests/dynamic_search.rs
+++ b/teaql-core/tests/dynamic_search.rs
@@ -1,0 +1,176 @@
+use std::collections::BTreeMap;
+use teaql_core::{dynamic_search::*, Expr, OrderBy, SelectQuery};
+
+fn models() -> SearchModels {
+    BTreeMap::from([
+        (
+            "School".into(),
+            SearchModel {
+                fields: [
+                    ("name", "string"),
+                    ("id", "integer"),
+                    ("active", "boolean"),
+                    ("amount", "decimal"),
+                    ("established_date", "date"),
+                    ("create_time", "timestamp"),
+                    ("capacity", "number"),
+                ]
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+                relations: BTreeMap::from([("platform".into(), "Platform".into())]),
+            },
+        ),
+        (
+            "Platform".into(),
+            SearchModel {
+                fields: BTreeMap::from([("name".into(), "string".into())]),
+                ..Default::default()
+            },
+        ),
+    ])
+}
+#[test]
+fn unknown_complete_clauses_warn_without_values() {
+    let mut warnings = vec![];
+    let result = normalize_dynamic_search(r#"{"filter":{"name":"School","old_name":"secret","platform.old_name":"secret","missing.name":"secret","platform.name":"Campus"},"orderBy":[{"field":"gone","direction":"asc"},{"field":"id","direction":"desc"}]}"#,
+        "School", &models(), 100, Some(&mut |w| warnings.push(w.clone()))).unwrap();
+    assert_eq!(
+        result
+            .filters
+            .iter()
+            .map(|f| f.field_path.as_str())
+            .collect::<Vec<_>>(),
+        ["name", "platform.name"]
+    );
+    assert_eq!(result.orders.len(), 1);
+    assert_eq!(result.orders[0].field_path, "id");
+    assert_eq!(warnings.len(), 4);
+    let json = serde_json::to_string(&warnings).unwrap();
+    assert!(!json.contains("secret"));
+    assert!(json.contains("fieldPath"));
+    assert!(warnings
+        .iter()
+        .all(|w| w.code == "DYNAMIC_SEARCH_UNKNOWN_FIELD"));
+}
+#[test]
+fn invalid_input_remains_fatal() {
+    for source in [
+        "[]",
+        "{} {}",
+        r#"{"tenant":2}"#,
+        r#"{"filter":{"id":true}}"#,
+        r#"{"filter":{"id":1.2}}"#,
+        r#"{"filter":{"capacity":1e999}}"#,
+        r#"{"filter":{"established_date":"2026-02-30"}}"#,
+        r#"{"filter":{"gone":{"$wat":1}}}"#,
+        r#"{"filter":{"name":{"$in":1}}}"#,
+        r#"{"filter":{"constructor":1}}"#,
+        r#"{"filter":{"platform..name":1}}"#,
+        r#"{"orderBy":[{"field":"id","direction":"bad"}]}"#,
+    ] {
+        let mut warnings = vec![];
+        assert!(
+            normalize_dynamic_search(
+                source,
+                "School",
+                &models(),
+                100,
+                Some(&mut |w| warnings.push(w.clone()))
+            )
+            .is_err(),
+            "{source}"
+        );
+        assert!(warnings.is_empty());
+    }
+}
+#[test]
+fn dates_booleans_and_exact_decimal_strings_are_retained() {
+    let result = normalize_dynamic_search(r#"{"filter":{"id":1.0,"active":true,"amount":"12345678901234567890.123456789","established_date":"2024-02-29","create_time":1700000000000,"name":null}}"#,
+        "School", &models(), 100, None).unwrap();
+    assert_eq!(result.filters.len(), 6);
+    assert_eq!(
+        result
+            .filters
+            .iter()
+            .find(|f| f.field_path == "amount")
+            .unwrap()
+            .value,
+        "12345678901234567890.123456789"
+    );
+}
+#[test]
+fn limits_and_missing_relation_metadata_fail() {
+    assert!(normalize_dynamic_search(
+        r#"{"filter":{"name":"x","gone":1}}"#,
+        "School",
+        &models(),
+        1,
+        None
+    )
+    .is_err());
+    let source = serde_json::json!({"filter":{"id":{"$in":vec![1;1001]}}}).to_string();
+    assert!(normalize_dynamic_search(&source, "School", &models(), 100, None).is_err());
+    let mut broken = models();
+    broken.remove("Platform");
+    assert!(normalize_dynamic_search(
+        r#"{"filter":{"platform.name":"x"}}"#,
+        "School",
+        &broken,
+        100,
+        None
+    )
+    .is_err());
+}
+#[test]
+fn composition_preserves_the_original_scope_and_limits() {
+    let mut base = SelectQuery::new("School")
+        .filter(Expr::eq("tenant_id", 7i64))
+        .order_by(OrderBy::desc("id"))
+        .limit(2)
+        .comment("what: tenant search");
+    base.hard_limit = 3;
+    let before = base.clone();
+    let mut warnings = vec![];
+    let result = merge_dynamic_search(
+        &base,
+        r#"{"filter":{"name":"School","gone":1},"orderBy":[{"field":"name","direction":"asc"}]}"#,
+        &models(),
+        |f| Ok(Expr::eq(&f.field_path, f.value.as_str().unwrap())),
+        |o| Ok(OrderBy::asc(&o.field_path)),
+        Some(&mut |w| warnings.push(w.clone())),
+    )
+    .unwrap();
+    assert_eq!(base, before);
+    assert_ne!(result.query.filter, base.filter);
+    assert_eq!(
+        result.query.order_by,
+        vec![OrderBy::desc("id"), OrderBy::asc("name")]
+    );
+    assert_eq!(result.query.slice, base.slice);
+    assert_eq!(result.query.hard_limit, 3);
+    assert_eq!(result.query.comment, base.comment);
+    assert_eq!(warnings.len(), 1);
+}
+#[test]
+fn late_failures_do_not_emit_warnings() {
+    let mut warnings = vec![];
+    assert!(normalize_dynamic_search(
+        r#"{"filter":{"gone":1,"id":"bad"}}"#,
+        "School",
+        &models(),
+        100,
+        Some(&mut |w| warnings.push(w.clone()))
+    )
+    .is_err());
+    assert!(merge_dynamic_search(
+        &SelectQuery::new("School"),
+        r#"{"filter":{"gone":1,"name":"School"}}"#,
+        &models(),
+        |_| Err(DynamicSearchError("binding failure")),
+        |o| Ok(OrderBy::asc(&o.field_path)),
+        Some(&mut |w| warnings.push(w.clone()))
+    )
+    .is_err());
+    assert!(warnings.is_empty());
+}

--- a/teaql-core/tests/dynamic_search.rs
+++ b/teaql-core/tests/dynamic_search.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use teaql_core::{dynamic_search::*, Expr, OrderBy, SelectQuery};
+use teaql_core::{Expr, OrderBy, SelectQuery, dynamic_search::*};
 
 fn models() -> SearchModels {
     BTreeMap::from([
@@ -49,9 +49,11 @@ fn unknown_complete_clauses_warn_without_values() {
     let json = serde_json::to_string(&warnings).unwrap();
     assert!(!json.contains("secret"));
     assert!(json.contains("fieldPath"));
-    assert!(warnings
-        .iter()
-        .all(|w| w.code == "DYNAMIC_SEARCH_UNKNOWN_FIELD"));
+    assert!(
+        warnings
+            .iter()
+            .all(|w| w.code == "DYNAMIC_SEARCH_UNKNOWN_FIELD")
+    );
 }
 #[test]
 fn invalid_input_remains_fatal() {
@@ -101,26 +103,30 @@ fn dates_booleans_and_exact_decimal_strings_are_retained() {
 }
 #[test]
 fn limits_and_missing_relation_metadata_fail() {
-    assert!(normalize_dynamic_search(
-        r#"{"filter":{"name":"x","gone":1}}"#,
-        "School",
-        &models(),
-        1,
-        None
-    )
-    .is_err());
+    assert!(
+        normalize_dynamic_search(
+            r#"{"filter":{"name":"x","gone":1}}"#,
+            "School",
+            &models(),
+            1,
+            None
+        )
+        .is_err()
+    );
     let source = serde_json::json!({"filter":{"id":{"$in":vec![1;1001]}}}).to_string();
     assert!(normalize_dynamic_search(&source, "School", &models(), 100, None).is_err());
     let mut broken = models();
     broken.remove("Platform");
-    assert!(normalize_dynamic_search(
-        r#"{"filter":{"platform.name":"x"}}"#,
-        "School",
-        &broken,
-        100,
-        None
-    )
-    .is_err());
+    assert!(
+        normalize_dynamic_search(
+            r#"{"filter":{"platform.name":"x"}}"#,
+            "School",
+            &broken,
+            100,
+            None
+        )
+        .is_err()
+    );
 }
 #[test]
 fn composition_preserves_the_original_scope_and_limits() {
@@ -155,22 +161,26 @@ fn composition_preserves_the_original_scope_and_limits() {
 #[test]
 fn late_failures_do_not_emit_warnings() {
     let mut warnings = vec![];
-    assert!(normalize_dynamic_search(
-        r#"{"filter":{"gone":1,"id":"bad"}}"#,
-        "School",
-        &models(),
-        100,
-        Some(&mut |w| warnings.push(w.clone()))
-    )
-    .is_err());
-    assert!(merge_dynamic_search(
-        &SelectQuery::new("School"),
-        r#"{"filter":{"gone":1,"name":"School"}}"#,
-        &models(),
-        |_| Err(DynamicSearchError("binding failure")),
-        |o| Ok(OrderBy::asc(&o.field_path)),
-        Some(&mut |w| warnings.push(w.clone()))
-    )
-    .is_err());
+    assert!(
+        normalize_dynamic_search(
+            r#"{"filter":{"gone":1,"id":"bad"}}"#,
+            "School",
+            &models(),
+            100,
+            Some(&mut |w| warnings.push(w.clone()))
+        )
+        .is_err()
+    );
+    assert!(
+        merge_dynamic_search(
+            &SelectQuery::new("School"),
+            r#"{"filter":{"gone":1,"name":"School"}}"#,
+            &models(),
+            |_| Err(DynamicSearchError("binding failure")),
+            |o| Ok(OrderBy::asc(&o.field_path)),
+            Some(&mut |w| warnings.push(w.clone()))
+        )
+        .is_err()
+    );
     assert!(warnings.is_empty());
 }

--- a/teaql-provider-sqlite/tests/dynamic_search.rs
+++ b/teaql-provider-sqlite/tests/dynamic_search.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, sync::Arc};
 use teaql_core::{
-    dynamic_search::*, DataType, EntityDescriptor, Expr, InsertCommand, OrderBy,
-    PropertyDescriptor, SelectQuery, TraceKind, TraceNode, Value,
+    DataType, EntityDescriptor, Expr, InsertCommand, OrderBy, PropertyDescriptor, SelectQuery,
+    TraceKind, TraceNode, Value, dynamic_search::*,
 };
 use teaql_data_service::{QueryExecutor, QueryRequest, SchemaProvider};
 use teaql_provider_sqlite::{SqliteDialect, SqliteMutationExecutor};

--- a/teaql-provider-sqlite/tests/dynamic_search.rs
+++ b/teaql-provider-sqlite/tests/dynamic_search.rs
@@ -1,0 +1,137 @@
+use std::{collections::BTreeMap, sync::Arc};
+use teaql_core::{
+    dynamic_search::*, DataType, EntityDescriptor, Expr, InsertCommand, OrderBy,
+    PropertyDescriptor, SelectQuery, TraceKind, TraceNode, Value,
+};
+use teaql_data_service::{QueryExecutor, QueryRequest, SchemaProvider};
+use teaql_provider_sqlite::{SqliteDialect, SqliteMutationExecutor};
+use teaql_sql::{SqlDataServiceExecutor, SqlDialect};
+
+#[derive(Clone)]
+struct Schema(Vec<Arc<EntityDescriptor>>);
+impl SchemaProvider for Schema {
+    fn get_entity(&self, name: &str) -> Option<Arc<EntityDescriptor>> {
+        self.0.iter().find(|e| e.name == name).cloned()
+    }
+}
+
+#[test]
+fn scoped_dynamic_search_retains_outer_and_related_tenant_filters() {
+    futures_executor::block_on(async {
+        let platform = EntityDescriptor::new("Platform")
+            .table_name("search_platform")
+            .property(PropertyDescriptor::new("id", DataType::I64).id())
+            .property(PropertyDescriptor::new("tenant_id", DataType::I64))
+            .property(PropertyDescriptor::new("name", DataType::Text));
+        let school = EntityDescriptor::new("School")
+            .table_name("search_school")
+            .property(PropertyDescriptor::new("id", DataType::I64).id())
+            .property(PropertyDescriptor::new("tenant_id", DataType::I64))
+            .property(PropertyDescriptor::new("platform_id", DataType::I64))
+            .property(PropertyDescriptor::new("name", DataType::Text));
+        let transport = SqliteMutationExecutor::from_connection(
+            rusqlite::Connection::open_in_memory().unwrap(),
+        );
+        // Provider boundary fixture, separate from generated bootstrap lifecycle tests.
+        transport
+            .ensure_schema(&SqliteDialect, &[&platform, &school])
+            .unwrap();
+        for (id, tenant) in [(1i64, 7i64), (2, 8)] {
+            let command = InsertCommand::new("Platform")
+                .value("id", id)
+                .value("tenant_id", tenant)
+                .value("name", "Campus");
+            transport
+                .execute(&SqliteDialect.compile_insert(&platform, &command).unwrap())
+                .unwrap();
+        }
+        for (id, tenant, parent, name) in [
+            (1i64, 7i64, 1i64, "School"),
+            (2, 7, 1, "School"),
+            (3, 7, 1, "School"),
+            (4, 8, 1, "School"),
+            (5, 7, 2, "School"),
+            (6, 7, 1, "Other"),
+        ] {
+            let command = InsertCommand::new("School")
+                .value("id", id)
+                .value("tenant_id", tenant)
+                .value("platform_id", parent)
+                .value("name", name);
+            transport
+                .execute(&SqliteDialect.compile_insert(&school, &command).unwrap())
+                .unwrap();
+        }
+        let executor = SqlDataServiceExecutor::new(
+            SqliteDialect,
+            transport,
+            Schema(vec![Arc::new(platform.clone()), Arc::new(school)]),
+        );
+        let models = BTreeMap::from([
+            (
+                "School".into(),
+                SearchModel {
+                    fields: BTreeMap::from([
+                        ("id".into(), "integer".into()),
+                        ("name".into(), "string".into()),
+                    ]),
+                    relations: BTreeMap::from([("platform".into(), "Platform".into())]),
+                },
+            ),
+            (
+                "Platform".into(),
+                SearchModel {
+                    fields: BTreeMap::from([("name".into(), "string".into())]),
+                    ..Default::default()
+                },
+            ),
+        ]);
+        let mut base = SelectQuery::new("School")
+            .project("id")
+            .project("name")
+            .filter(Expr::eq("tenant_id", 7i64))
+            .order_by(OrderBy::desc("id"))
+            .limit(2)
+            .comment("what: search tenant schools");
+        base.hard_limit = 2;
+        base.trace_chain.push(TraceNode::typed(
+            TraceKind::Purpose,
+            "School",
+            None,
+            "why: verify schema drift isolation",
+        ));
+        let before = base.clone();
+        let mut warnings = vec![];
+        let result = merge_dynamic_search(&base,
+            r#"{"filter":{"name":"School","platform.name":"Campus","old_name":"secret","old_relation.name":"secret","platform.old_name":"secret"},"orderBy":[{"field":"removed","direction":"asc"},{"field":"name","direction":"asc"}]}"#,
+            &models, |filter| match filter.field_path.as_str() {
+                "name" => Ok(Expr::eq("name", filter.value.as_str().unwrap())),
+                "platform.name" => Ok(Expr::in_subquery("platform_id", platform.clone(),
+                    SelectQuery::new("Platform").filter(Expr::eq("tenant_id", 7i64))
+                        .and_filter(Expr::eq("name", filter.value.as_str().unwrap())), "id")),
+                _ => Err(DynamicSearchError("Unbound trusted field")),
+            }, |order| Ok(OrderBy::asc(&order.field_path)), Some(&mut |w| warnings.push(w.clone()))).unwrap();
+        assert_eq!(base, before);
+        assert_eq!(result.query.hard_limit, 2);
+        assert_eq!(result.query.trace_chain, base.trace_chain);
+        let response = executor
+            .query(QueryRequest {
+                query: result.query,
+                comment: base.comment,
+                trace_chain: base.trace_chain,
+                capture_debug_query: true,
+                capture_execution_metadata: true,
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            response
+                .rows
+                .iter()
+                .map(|row| row.get("id").cloned())
+                .collect::<Vec<_>>(),
+            vec![Some(Value::I64(3)), Some(Value::I64(2))]
+        );
+        assert_eq!(warnings.len(), 4);
+    });
+}

--- a/teaql-runtime/Cargo.toml
+++ b/teaql-runtime/Cargo.toml
@@ -13,6 +13,7 @@ futures-core = "0.3"
 futures-util = "0.3"
 chrono = { workspace = true }
 serde_json = { workspace = true }
+serde = { workspace = true }
 rust_decimal = { workspace = true }
 teaql-core = { workspace = true }
 teaql-sql = { workspace = true }

--- a/teaql-runtime/src/checker.rs
+++ b/teaql-runtime/src/checker.rs
@@ -351,9 +351,9 @@ impl CheckResult {
                 .segments
                 .iter()
                 .map(|segment| match segment {
-                    LocationSegment::Member(name) => WireLocationSegment::Property {
-                        name: name.clone(),
-                    },
+                    LocationSegment::Member(name) => {
+                        WireLocationSegment::Property { name: name.clone() }
+                    }
                     LocationSegment::Index(index) => WireLocationSegment::Index { index: *index },
                 })
                 .collect(),

--- a/teaql-runtime/src/checker.rs
+++ b/teaql-runtime/src/checker.rs
@@ -69,10 +69,59 @@ pub enum CheckRule {
     ContextRootMismatch,
 }
 
+impl CheckRule {
+    pub fn wire_id(self) -> &'static str {
+        match self {
+            Self::Required => "required",
+            Self::InvalidType => "invalid_type",
+            Self::Min => "min",
+            Self::Max => "max",
+            Self::MinStringLength => "min_string_length",
+            Self::MaxStringLength => "max_string_length",
+            Self::ContextRootMissing => "context_root_missing",
+            Self::ContextRootMismatch => "context_root_mismatch",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LocationSegment {
     Member(String),
     Index(usize),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum JsonFieldNamingProfile {
+    #[default]
+    CamelCase,
+    SnakeCase,
+    PascalCase,
+}
+
+impl JsonFieldNamingProfile {
+    pub fn from_model_value(value: &str) -> Result<Self, String> {
+        match value {
+            "" | "camelCase" => Ok(Self::CamelCase),
+            "snake_case" => Ok(Self::SnakeCase),
+            "PascalCase" => Ok(Self::PascalCase),
+            other => Err(format!("unsupported json_field_naming: {other}")),
+        }
+    }
+
+    fn render(self, name: &str) -> String {
+        match self {
+            Self::SnakeCase => name.to_owned(),
+            Self::CamelCase => lower_camel(name),
+            Self::PascalCase => {
+                let camel = lower_camel(name);
+                let mut chars = camel.chars();
+                chars
+                    .next()
+                    .map(|first| first.to_uppercase().chain(chars).collect())
+                    .unwrap_or_default()
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -123,11 +172,15 @@ impl ObjectLocation {
 
     /// RFC 6901 JSON pointer using TeaQL's default lower-camel wire policy.
     pub fn instance_path(&self) -> String {
+        self.instance_path_with(JsonFieldNamingProfile::CamelCase)
+    }
+
+    pub fn instance_path_with(&self, profile: JsonFieldNamingProfile) -> String {
         self.segments
             .iter()
             .map(|segment| match segment {
                 LocationSegment::Member(member) => {
-                    format!("/{}", escape_json_pointer(&lower_camel(member)))
+                    format!("/{}", escape_json_pointer(&profile.render(member)))
                 }
                 LocationSegment::Index(index) => format!("/{index}"),
             })
@@ -199,6 +252,20 @@ pub struct CheckResult {
     pub input_value: Option<Value>,
     pub system_value: Option<Value>,
     pub message: Option<String>,
+    pub entity_type: Option<String>,
+    pub source_instance_path: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct WireCheckResult<'a> {
+    pub rule_id: String,
+    pub entity_type: Option<&'a str>,
+    pub location: &'a [LocationSegment],
+    pub instance_path: String,
+    pub source_instance_path: Option<&'a str>,
+    pub input_value: Option<&'a Value>,
+    pub system_value: Option<&'a Value>,
+    pub message: Option<&'a str>,
 }
 
 impl CheckResult {
@@ -209,6 +276,8 @@ impl CheckResult {
             input_value: None,
             system_value: None,
             message: None,
+            entity_type: None,
+            source_instance_path: None,
         }
     }
 
@@ -253,6 +322,29 @@ impl CheckResult {
     pub fn with_message(mut self, message: impl Into<String>) -> Self {
         self.message = Some(message.into());
         self
+    }
+
+    pub fn with_entity_type(mut self, entity_type: impl Into<String>) -> Self {
+        self.entity_type = Some(entity_type.into());
+        self
+    }
+
+    pub fn with_source_instance_path(mut self, path: impl Into<String>) -> Self {
+        self.source_instance_path = Some(path.into());
+        self
+    }
+
+    pub fn to_wire(&self, profile: JsonFieldNamingProfile) -> WireCheckResult<'_> {
+        WireCheckResult {
+            rule_id: self.rule.wire_id().to_owned(),
+            entity_type: self.entity_type.as_deref(),
+            location: &self.location.segments,
+            instance_path: self.location.instance_path_with(profile),
+            source_instance_path: self.source_instance_path.as_deref(),
+            input_value: self.input_value.as_ref(),
+            system_value: self.system_value.as_ref(),
+            message: self.message.as_deref(),
+        }
     }
 }
 
@@ -540,7 +632,27 @@ mod tests {
         assert_eq!(location.model_path(), "order_items[2].user_url");
         assert_eq!(location.native_path(), "order_items[2].user_url");
         assert_eq!(location.instance_path(), "/orderItems/2/userUrl");
+        assert_eq!(
+            location.instance_path_with(JsonFieldNamingProfile::SnakeCase),
+            "/order_items/2/user_url"
+        );
+        assert_eq!(
+            location.instance_path_with(JsonFieldNamingProfile::PascalCase),
+            "/OrderItems/2/UserUrl"
+        );
         assert_eq!(location.to_string(), "order_items[2].user_url");
+    }
+
+    #[test]
+    fn checker_wire_projection_preserves_submitted_alias() {
+        let result = CheckResult::required(ObjectLocation::hash_root("user_url"))
+            .with_entity_type("customer_account")
+            .with_source_instance_path("/user_url");
+        let wire = result.to_wire(JsonFieldNamingProfile::CamelCase);
+        assert_eq!(wire.rule_id, "required");
+        assert_eq!(wire.entity_type, Some("customer_account"));
+        assert_eq!(wire.instance_path, "/userUrl");
+        assert_eq!(wire.source_instance_path, Some("/user_url"));
     }
 
     #[test]

--- a/teaql-runtime/src/checker.rs
+++ b/teaql-runtime/src/checker.rs
@@ -256,16 +256,24 @@ pub struct CheckResult {
     pub source_instance_path: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct WireCheckResult<'a> {
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WireCheckResult {
     pub rule_id: String,
-    pub entity_type: Option<&'a str>,
-    pub location: &'a [LocationSegment],
+    pub entity_type: Option<String>,
+    pub location: Vec<WireLocationSegment>,
     pub instance_path: String,
-    pub source_instance_path: Option<&'a str>,
-    pub input_value: Option<&'a Value>,
-    pub system_value: Option<&'a Value>,
-    pub message: Option<&'a str>,
+    pub source_instance_path: Option<String>,
+    pub input_value: Option<serde_json::Value>,
+    pub system_value: Option<serde_json::Value>,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum WireLocationSegment {
+    Property { name: String },
+    Index { index: usize },
 }
 
 impl CheckResult {
@@ -334,16 +342,26 @@ impl CheckResult {
         self
     }
 
-    pub fn to_wire(&self, profile: JsonFieldNamingProfile) -> WireCheckResult<'_> {
+    pub fn to_wire(&self, profile: JsonFieldNamingProfile) -> WireCheckResult {
         WireCheckResult {
             rule_id: self.rule.wire_id().to_owned(),
-            entity_type: self.entity_type.as_deref(),
-            location: &self.location.segments,
+            entity_type: self.entity_type.clone(),
+            location: self
+                .location
+                .segments
+                .iter()
+                .map(|segment| match segment {
+                    LocationSegment::Member(name) => WireLocationSegment::Property {
+                        name: name.clone(),
+                    },
+                    LocationSegment::Index(index) => WireLocationSegment::Index { index: *index },
+                })
+                .collect(),
             instance_path: self.location.instance_path_with(profile),
-            source_instance_path: self.source_instance_path.as_deref(),
-            input_value: self.input_value.as_ref(),
-            system_value: self.system_value.as_ref(),
-            message: self.message.as_deref(),
+            source_instance_path: self.source_instance_path.clone(),
+            input_value: self.input_value.as_ref().map(Value::to_json_value),
+            system_value: self.system_value.as_ref().map(Value::to_json_value),
+            message: self.message.clone(),
         }
     }
 }
@@ -650,9 +668,17 @@ mod tests {
             .with_source_instance_path("/user_url");
         let wire = result.to_wire(JsonFieldNamingProfile::CamelCase);
         assert_eq!(wire.rule_id, "required");
-        assert_eq!(wire.entity_type, Some("customer_account"));
+        assert_eq!(wire.entity_type.as_deref(), Some("customer_account"));
         assert_eq!(wire.instance_path, "/userUrl");
-        assert_eq!(wire.source_instance_path, Some("/user_url"));
+        assert_eq!(wire.source_instance_path.as_deref(), Some("/user_url"));
+
+        let json = serde_json::to_value(&wire).expect("wire result must serialize");
+        assert_eq!(json["ruleId"], "required");
+        assert_eq!(json["entityType"], "customer_account");
+        assert_eq!(json["location"][0]["kind"], "property");
+        assert_eq!(json["location"][0]["name"], "user_url");
+        assert_eq!(json["instancePath"], "/userUrl");
+        assert_eq!(json["sourceInstancePath"], "/user_url");
     }
 
     #[test]

--- a/teaql-runtime/src/lib.rs
+++ b/teaql-runtime/src/lib.rs
@@ -3722,6 +3722,7 @@ mod tests {
 pub use checker::{
     CHECK_OBJECT_STATUS_FIELD, CheckObjectStatus, CheckResult, CheckResults, CheckRule, Checker,
     CheckerRegistry, InMemoryCheckerRegistry, JsonFieldNamingProfile, LocationSegment,
-    ObjectLocation, TypedChecker, TypedEntityChecker, WireCheckResult, clear_entity_status,
+    ObjectLocation, TypedChecker, TypedEntityChecker, WireCheckResult, WireLocationSegment,
+    clear_entity_status,
     mark_entity_status,
 };

--- a/teaql-runtime/src/lib.rs
+++ b/teaql-runtime/src/lib.rs
@@ -3723,6 +3723,5 @@ pub use checker::{
     CHECK_OBJECT_STATUS_FIELD, CheckObjectStatus, CheckResult, CheckResults, CheckRule, Checker,
     CheckerRegistry, InMemoryCheckerRegistry, JsonFieldNamingProfile, LocationSegment,
     ObjectLocation, TypedChecker, TypedEntityChecker, WireCheckResult, WireLocationSegment,
-    clear_entity_status,
-    mark_entity_status,
+    clear_entity_status, mark_entity_status,
 };

--- a/teaql-runtime/src/lib.rs
+++ b/teaql-runtime/src/lib.rs
@@ -3721,6 +3721,7 @@ mod tests {
 
 pub use checker::{
     CHECK_OBJECT_STATUS_FIELD, CheckObjectStatus, CheckResult, CheckResults, CheckRule, Checker,
-    CheckerRegistry, InMemoryCheckerRegistry, LocationSegment, ObjectLocation, TypedChecker,
-    TypedEntityChecker, clear_entity_status, mark_entity_status,
+    CheckerRegistry, InMemoryCheckerRegistry, JsonFieldNamingProfile, LocationSegment,
+    ObjectLocation, TypedChecker, TypedEntityChecker, WireCheckResult, clear_entity_status,
+    mark_entity_status,
 };

--- a/teaql-tfp-endpoint/examples/conformance_server.rs
+++ b/teaql-tfp-endpoint/examples/conformance_server.rs
@@ -179,6 +179,7 @@ fn trusted() -> TrustedQueryContext {
                 "Recover".into(),
             ]),
         )]),
+        wire_metadata: BTreeMap::new(),
         max_page_size: 100,
     }
 }

--- a/teaql-tfp-endpoint/src/lib.rs
+++ b/teaql-tfp-endpoint/src/lib.rs
@@ -23,7 +23,121 @@ pub struct TrustedQueryContext {
     pub writable_field_mappings:
         std::collections::BTreeMap<String, std::collections::BTreeMap<String, String>>,
     pub allowed_actions: std::collections::BTreeMap<String, std::collections::BTreeSet<String>>,
+    /// Generated serializer-independent field metadata, keyed by entity name.
+    pub wire_metadata: std::collections::BTreeMap<String, WireEntityMetadata>,
     pub max_page_size: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WireEntityMetadata {
+    pub canonical_to_wire: std::collections::BTreeMap<String, String>,
+    accepted_to_canonical: std::collections::BTreeMap<String, String>,
+}
+
+impl WireEntityMetadata {
+    pub fn new(
+        canonical_to_wire: std::collections::BTreeMap<String, String>,
+        aliases: std::collections::BTreeMap<String, String>,
+    ) -> Result<Self, String> {
+        let mut accepted = std::collections::BTreeMap::new();
+        for (canonical, wire) in &canonical_to_wire {
+            register_wire_name(&mut accepted, canonical, canonical)?;
+            register_wire_name(&mut accepted, wire, canonical)?;
+        }
+        for (alias, canonical) in aliases {
+            if !canonical_to_wire.contains_key(&canonical) {
+                return Err(format!("Unknown canonical field for alias: {canonical}"));
+            }
+            register_wire_name(&mut accepted, &alias, &canonical)?;
+        }
+        Ok(Self {
+            canonical_to_wire,
+            accepted_to_canonical: accepted,
+        })
+    }
+
+    pub fn canonical_field(&self, submitted: &str) -> Option<&str> {
+        self.accepted_to_canonical
+            .get(submitted)
+            .map(String::as_str)
+    }
+
+    fn accepted_policy_map(
+        &self,
+        canonical_policy: &std::collections::BTreeMap<String, String>,
+    ) -> std::collections::BTreeMap<String, String> {
+        self.accepted_to_canonical
+            .iter()
+            .filter_map(|(accepted, canonical)| {
+                canonical_policy
+                    .get(canonical)
+                    .map(|internal| (accepted.clone(), internal.clone()))
+            })
+            .collect()
+    }
+}
+
+fn register_wire_name(
+    accepted: &mut std::collections::BTreeMap<String, String>,
+    name: &str,
+    canonical: &str,
+) -> Result<(), String> {
+    if let Some(previous) = accepted.insert(name.to_owned(), canonical.to_owned())
+        && previous != canonical
+    {
+        return Err(format!("Wire field alias is ambiguous: {name}"));
+    }
+    Ok(())
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct NormalizedWireObject {
+    pub values: serde_json::Map<String, JsonValue>,
+    pub source_instance_paths: std::collections::BTreeMap<String, String>,
+}
+
+pub fn normalize_wire_object(
+    submitted: &serde_json::Map<String, JsonValue>,
+    metadata: &WireEntityMetadata,
+) -> Result<NormalizedWireObject, TfpEndpointError> {
+    let mut values = serde_json::Map::new();
+    let mut paths = std::collections::BTreeMap::new();
+    for (name, value) in submitted {
+        let canonical = metadata.canonical_field(name).ok_or_else(|| {
+            TfpEndpointError::WireInput(format!("Unknown field at /{}", escape_pointer(name)))
+        })?;
+        if values.contains_key(canonical) {
+            return Err(TfpEndpointError::WireCollision(format!(
+                "Multiple submitted fields resolve to {canonical}"
+            )));
+        }
+        values.insert(canonical.to_owned(), value.clone());
+        paths.insert(canonical.to_owned(), format!("/{}", escape_pointer(name)));
+    }
+    Ok(NormalizedWireObject {
+        values,
+        source_instance_paths: paths,
+    })
+}
+
+/// Adds the submitted alias path without changing the canonical KSML checker location.
+pub fn retain_submitted_paths(
+    results: &mut [teaql_runtime::CheckResult],
+    normalized: &NormalizedWireObject,
+) {
+    for result in results {
+        let wire = result.to_wire(teaql_runtime::JsonFieldNamingProfile::SnakeCase);
+        let Some(teaql_runtime::LocationSegment::Member(canonical)) = wire.location.first() else {
+            continue;
+        };
+        if let Some(path) = normalized.source_instance_paths.get(canonical) {
+            result.source_instance_path = Some(path.clone());
+        }
+    }
+}
+
+fn escape_pointer(value: &str) -> String {
+    value.replace('~', "~0").replace('/', "~1")
 }
 
 #[derive(Error, Debug)]
@@ -34,6 +148,10 @@ pub enum TfpEndpointError {
     TranslationError(String),
     #[error("Data service error: {0}")]
     ExecutionError(String),
+    #[error("Invalid wire input: {0}")]
+    WireInput(String),
+    #[error("Conflicting wire input: {0}")]
+    WireCollision(String),
 }
 
 impl TfpEndpointError {
@@ -70,6 +188,8 @@ impl TfpEndpointError {
             }
             Self::TranslationError(_) => "TFP_POLICY_VIOLATION",
             Self::ExecutionError(_) => "TFP_EXECUTION_FAILED",
+            Self::WireInput(_) => "WIRE_UNKNOWN_FIELD",
+            Self::WireCollision(_) => "WIRE_FIELD_COLLISION",
         }
     }
 }
@@ -165,15 +285,21 @@ where
             serde_json::from_value(json_payload).map_err(TfpEndpointError::ParseError)?;
 
         validate_policy(trusted, &tfp_query).map_err(TfpEndpointError::TranslationError)?;
-        let mappings = trusted
-            .field_mappings
+        let configured_mappings =
+            trusted
+                .field_mappings
+                .get(&tfp_query.entity)
+                .ok_or_else(|| {
+                    TfpEndpointError::TranslationError(format!(
+                        "No field policy for entity: {}",
+                        tfp_query.entity
+                    ))
+                })?;
+        let generated_mappings = trusted
+            .wire_metadata
             .get(&tfp_query.entity)
-            .ok_or_else(|| {
-                TfpEndpointError::TranslationError(format!(
-                    "No field policy for entity: {}",
-                    tfp_query.entity
-                ))
-            })?;
+            .map(|metadata| metadata.accepted_policy_map(configured_mappings));
+        let mappings = generated_mappings.as_ref().unwrap_or(configured_mappings);
         prepare_facets(trusted, &mut tfp_query).map_err(TfpEndpointError::TranslationError)?;
         tfp_query
             .map_fields(mappings)
@@ -420,6 +546,13 @@ where
                     tfp_mutation.entity
                 ))
             })?;
+        if let Some(metadata) = trusted.wire_metadata.get(&tfp_mutation.entity) {
+            let object = tfp_mutation.payload.as_object().ok_or_else(|| {
+                TfpEndpointError::TranslationError("Mutation payload must be an object".into())
+            })?;
+            tfp_mutation.payload =
+                JsonValue::Object(normalize_wire_object(object, metadata)?.values);
+        }
         tfp_mutation
             .map_writable_fields(mappings)
             .map_err(TfpEndpointError::TranslationError)?;
@@ -559,10 +692,7 @@ fn validate_policy(trusted: &TrustedQueryContext, query: &TfpSelectQuery) -> Res
     if query.limit_value.unwrap_or(0) > trusted.max_page_size {
         return Err("Page size exceeds federation policy".into());
     }
-    let allowed = trusted
-        .field_mappings
-        .get(&query.entity)
-        .ok_or_else(|| format!("No field policy for entity: {}", query.entity))?;
+    let allowed = effective_field_mappings(trusted, &query.entity, false)?;
     for field in query
         .order_items
         .iter()
@@ -584,10 +714,7 @@ fn prepare_facets(trusted: &TrustedQueryContext, query: &mut TfpSelectQuery) -> 
     if query.facets.len() > 10 {
         return Err("A TFP query may contain at most 10 facets".into());
     }
-    let outer_fields = trusted
-        .field_mappings
-        .get(&query.entity)
-        .ok_or_else(|| format!("No field policy for entity: {}", query.entity))?;
+    let outer_fields = effective_field_mappings(trusted, &query.entity, false)?;
     let mut names = std::collections::BTreeSet::new();
     for facet in &mut query.facets {
         if facet.facet_name.is_empty()
@@ -615,10 +742,7 @@ fn prepare_facets(trusted: &TrustedQueryContext, query: &mut TfpSelectQuery) -> 
             return Err("Nested facets are not supported by TFP".into());
         }
         validate_policy(trusted, &facet.query)?;
-        let nested_fields = trusted
-            .field_mappings
-            .get(&facet.query.entity)
-            .ok_or_else(|| format!("No field policy for entity: {}", facet.query.entity))?;
+        let nested_fields = effective_field_mappings(trusted, &facet.query.entity, false)?;
         if facet.query.aggregate_items.is_empty()
             || facet
                 .query
@@ -645,9 +769,27 @@ fn prepare_facets(trusted: &TrustedQueryContext, query: &mut TfpSelectQuery) -> 
         {
             return Err("Facet query commentText and purposeText are required".into());
         }
-        facet.query.map_fields(nested_fields)?;
+        facet.query.map_fields(&nested_fields)?;
     }
     Ok(())
+}
+
+fn effective_field_mappings(
+    trusted: &TrustedQueryContext,
+    entity: &str,
+    writable: bool,
+) -> Result<std::collections::BTreeMap<String, String>, String> {
+    let configured = if writable {
+        trusted.writable_field_mappings.get(entity)
+    } else {
+        trusted.field_mappings.get(entity)
+    }
+    .ok_or_else(|| format!("No field policy for entity: {entity}"))?;
+    Ok(trusted
+        .wire_metadata
+        .get(entity)
+        .map(|metadata| metadata.accepted_policy_map(configured))
+        .unwrap_or_else(|| configured.clone()))
 }
 
 fn validate_mutation_policy(
@@ -852,6 +994,7 @@ mod tests {
                     "Recover".into(),
                 ]),
             )]),
+            wire_metadata: BTreeMap::new(),
             max_page_size: 100,
         }
     }
@@ -1064,5 +1207,49 @@ mod tests {
         ] {
             assert!(endpoint.handle_mutation(&trusted(), payload).await.is_err());
         }
+    }
+
+    #[test]
+    fn wire_metadata_matches_typescript_fixture_and_rejects_collisions() {
+        let metadata = WireEntityMetadata::new(
+            BTreeMap::from([
+                ("user_url".into(), "userUrl".into()),
+                ("school_type".into(), "schoolType".into()),
+            ]),
+            BTreeMap::from([("legacyUrl".into(), "user_url".into())]),
+        )
+        .unwrap();
+        let submitted = json!({"legacyUrl":"https://teaql.io","schoolType":1001});
+        let normalized = normalize_wire_object(submitted.as_object().unwrap(), &metadata).unwrap();
+        assert_eq!(normalized.values["user_url"], json!("https://teaql.io"));
+        assert_eq!(normalized.values["school_type"], json!(1001));
+        assert_eq!(normalized.source_instance_paths["user_url"], "/legacyUrl");
+        assert_eq!(
+            normalized.source_instance_paths["school_type"],
+            "/schoolType"
+        );
+        let mut violations = vec![teaql_runtime::CheckResult::required(
+            teaql_runtime::ObjectLocation::hash_root("user_url"),
+        )];
+        retain_submitted_paths(&mut violations, &normalized);
+        assert_eq!(
+            violations[0].source_instance_path.as_deref(),
+            Some("/legacyUrl")
+        );
+
+        let collision = json!({"userUrl":"a","legacyUrl":"a"});
+        assert_eq!(
+            normalize_wire_object(collision.as_object().unwrap(), &metadata)
+                .unwrap_err()
+                .code(),
+            "WIRE_FIELD_COLLISION"
+        );
+        let unknown = json!({"unknown":1});
+        assert_eq!(
+            normalize_wire_object(unknown.as_object().unwrap(), &metadata)
+                .unwrap_err()
+                .code(),
+            "WIRE_UNKNOWN_FIELD"
+        );
     }
 }

--- a/teaql-tfp-endpoint/src/lib.rs
+++ b/teaql-tfp-endpoint/src/lib.rs
@@ -77,6 +77,21 @@ impl WireEntityMetadata {
     }
 }
 
+/// Converts dependency-free metadata emitted by a generated runtime module.
+pub fn wire_metadata_from_generated(
+    mappings: std::collections::BTreeMap<String, std::collections::BTreeMap<String, String>>,
+    mut aliases: std::collections::BTreeMap<String, std::collections::BTreeMap<String, String>>,
+) -> Result<std::collections::BTreeMap<String, WireEntityMetadata>, String> {
+    mappings
+        .into_iter()
+        .map(|(entity, fields)| {
+            let metadata =
+                WireEntityMetadata::new(fields, aliases.remove(&entity).unwrap_or_default())?;
+            Ok((entity, metadata))
+        })
+        .collect()
+}
+
 fn register_wire_name(
     accepted: &mut std::collections::BTreeMap<String, String>,
     name: &str,

--- a/teaql-tfp-endpoint/src/lib.rs
+++ b/teaql-tfp-endpoint/src/lib.rs
@@ -142,7 +142,9 @@ pub fn retain_submitted_paths(
 ) {
     for result in results {
         let wire = result.to_wire(teaql_runtime::JsonFieldNamingProfile::SnakeCase);
-        let Some(teaql_runtime::LocationSegment::Member(canonical)) = wire.location.first() else {
+        let Some(teaql_runtime::WireLocationSegment::Property { name: canonical }) =
+            wire.location.first()
+        else {
             continue;
         };
         if let Some(path) = normalized.source_instance_paths.get(canonical) {


### PR DESCRIPTION
Closes #116; includes the three pending Checker-profile commits tracked in #115. Adds trusted-metadata local UI search normalization and native Expr/OrderBy composition. Unknown complete clauses warn without values; malformed input remains fatal. Scope/limits/order/trace are preserved; TFP stays strict. Full workspace: 387 passed, 8 ignored (Redis external test plus doctests), zero failures. All Rust examples pass. New boundary tests and actual SQLite root/related tenant fixture pass. Generated automatic bindings, shared parity and publication remain separate gates. Root lock reflects existing serde dependency; generated example lockfile churn excluded.